### PR TITLE
Fix typo and make tests pass on clean dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ develop: install
 	python -m pip install --upgrade pip wheel setuptools twine
 	python setup.py develop
 	pre-commit install
+	python -m spacy download en_core_web_sm
+	python -m spacy download en_trf_robertabase_lg
 
 flake:
 	flake8 setup.py --count --statistics --max-complexity=10 --max-line-length=127

--- a/docs/api/language/s2v_lang.md
+++ b/docs/api/language/s2v_lang.md
@@ -1,3 +1,3 @@
 # `whatlies.language.Sense2VecLanguage`
 
-::: whatlies.language.Sense2VecLangauge
+::: whatlies.language.Sense2VecLanguage

--- a/docs/tutorial/languages/index.md
+++ b/docs/tutorial/languages/index.md
@@ -75,10 +75,10 @@ that you should be able to retreive tokens with context. They way you fetch thes
 tokens is a bit ... different though.
 
 ```python
-from whatlies.language.language import Sense2VecLangauge
+from whatlies.language.language import Sense2VecLanguage
 from whatlies.transformers import Pca
 
-lang = Sense2VecLangauge("path/downloaded/s2v")
+lang = Sense2VecLanguage("path/downloaded/s2v")
 
 words = ["bank|NOUN", "bank|VERB", "duck|NOUN", "duck|VERB",
          "dog|NOUN", "cat|NOUN", "jump|VERB", "run|VERB",

--- a/notebooks/03-interactive-transformations.ipynb
+++ b/notebooks/03-interactive-transformations.ipynb
@@ -17,6 +17,7 @@
    "outputs": [],
    "source": [
     "from whatlies import Embedding, EmbeddingSet\n",
+    "from whatlies.transformers import Pca, Umap\n",
     "import spacy "
    ]
   },
@@ -127,8 +128,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from whatlies.transformers import Pca, Umap\n",
-    "\n",
     "orig_chart = emb.plot_interactive('man', 'woman')\n",
     "pca_emb = emb.transform(Pca(2))\n",
     "umap_emb = emb.transform(Umap(2))\n",

--- a/notebooks/05-language-backends.ipynb
+++ b/notebooks/05-language-backends.ipynb
@@ -151,7 +151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/05-language-backends.ipynb
+++ b/notebooks/05-language-backends.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from whatlies.language import Sense2VecLangauge"
+    "from whatlies.language import Sense2VecLanguage"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lang = Sense2VecLangauge(\"../s2v_old/\")"
+    "lang = Sense2VecLanguage(\"../s2v_old/\")"
    ]
   },
   {
@@ -151,7 +151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/whatlies/language/__init__.py
+++ b/whatlies/language/__init__.py
@@ -1,5 +1,5 @@
 from .spacy_lang import SpacyLanguage
-from .sense2vec_lang import Sense2VecLangauge
+from .sense2vec_lang import Sense2VecLanguage
 from .fasttext_lang import FasttextLanguage
 
-__all__ = ["SpacyLanguage", "Sense2VecLangauge", "FasttextLanguage"]
+__all__ = ["SpacyLanguage", "Sense2VecLanguage", "FasttextLanguage"]

--- a/whatlies/language/sense2vec_lang.py
+++ b/whatlies/language/sense2vec_lang.py
@@ -5,7 +5,7 @@ from whatlies.embedding import Embedding
 from whatlies.embeddingset import EmbeddingSet
 
 
-class Sense2VecLangauge:
+class Sense2VecLanguage:
     """
     This object is used to lazily fetch [Embedding][whatlies.embedding.Embedding]s or
     [EmbeddingSet][whatlies.embeddingset.EmbeddingSet]s from a sense2vec language

--- a/whatlies/language/spacy_lang.py
+++ b/whatlies/language/spacy_lang.py
@@ -52,7 +52,7 @@ class SpacyLanguage:
         elif isinstance(model, Language):
             self.nlp = model
         else:
-            raise ValueError("Language must be started with `str` or spaCy-langauge object.")
+            raise ValueError("Language must be started with `str` or spaCy-language object.")
 
     @classmethod
     def from_fasttext(cls, language, output_dir, vectors_loc=None, force=False):


### PR DESCRIPTION
I must admit, this is not the most impactful PR 😁 but I'm in kurzarbeit today and I was reading your codebase and on the way I noticed this typo. So I fix it, I built the docs and ran the tests. and here am I.

Btw, congrats on that repo setup. It's so clean, it makes contributing / reading a breeze. Even down to the API of the makefile. Definitely going to try to emulate some of that in my repos going forward.

One remark though, it's a one time thing, but 
```sh
python -m spacy download en_core_web_sm
```
is missing from docs and the `make develop` command. Without that the notebook tests fail.
What are your thoughts on that? 

Note: I couldn't make tests pass for notebook 5 (I don't have the `../s2v_old/` folder). The rest is ✅ 