### PR TITLE
Correct import statement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ and use mathematical operations on it.
 
 ```python
 from whatlies import EmbeddingSet
-from whatlies.language.language import SpacyLanguage
+from whatlies.language import SpacyLanguage
 
 lang = SpacyLanguage("en_core_web_md")
 words = ["cat", "dog", "fish", "kitten", "man", "woman",


### PR DESCRIPTION
Fixes the import statement in the README snippet.

```python
from whatlies.language.language import SpacyLanguage # ❌ ModuleNotFoundError: No module named 'whatlies.language.language'
from whatlies.language import SpacyLanguage # ✅
```