### PR TITLE
Fix EmbeddingSet getitem method

### DIFF
--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -263,9 +263,9 @@ class EmbeddingSet:
         emb["buz"]
         ```
         """
-        if not isinstance(thing, list):
+        if isinstance(thing, str):
             return self.embeddings[thing]
-        new_embeddings = {k: emb for k, emb in self.embeddings.items()}
+        new_embeddings = {t: self[t] for t in thing}
         names = ",".join(thing)
         return EmbeddingSet(new_embeddings, name=f"{self.name}.subset({names})")
 


### PR DESCRIPTION
Currently, when a `tuple` or a `list` is used for getting items from an `EmbeddingSet` instance, it would return all the embeddings. This PR fixes this issue, so that a new `EmbeddingSet` is returned **containing only the requested embeddings**.