### PR TITLE
Fix error in transformers test file

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -6,7 +6,7 @@ from whatlies.transformers import Umap, Pca, Noise, AddRandom
 
 
 vocab = Vocab().from_disk("tests/custom_test_vocab/")
-words = [v.text for v in vocab]
+words = list(vocab.strings)
 lang = SpacyLanguage(nlp=Language(vocab=vocab, meta={"lang": "en"}))
 emb = lang[words]
 


### PR DESCRIPTION
Since `nlp.vocab` or `vocab` in spaCy is just a cache of used tokens, therefore when the vocab or language is loaded from disk the `vocab` would be empty and therefore iterating over it would result in an empty list (as a result the `words` list would be empty as well). That's why currently 11 transformers tests fail. Instead, we need to use `vocab.strings` and iterate over that.

Also keep in mind that when you persist a `Vocab` or `Language` instance in spaCy, another special string denoted as `'_SP'` is automatically added to the list of strings in the vocab (see [here][1] or [here][2]).

[1]: https://github.com/RasaHQ/whatlies/blob/2783be06fcc2ccea01fd17da9cabfc7f3aacb987/tests/custom_test_vocab/strings.json#L29

[2]: https://github.com/RasaHQ/whatlies/blob/2783be06fcc2ccea01fd17da9cabfc7f3aacb987/tests/custom_test_lang/vocab/strings.json#L29