### PR TITLE
Fix #63: Remove files option of black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,3 @@ repos:
     rev: stable
     hooks:
     -   id: black
-        files: sklego


### PR DESCRIPTION
This PR removes the `files` option of `black` hook so that all the code files, including tests, would be checked by `black`.

The repo needs to be checked by `black` since none of the files have been checked so far; but I think it's better to put that in another PR (if needed).