### PR TITLE
Add support for different ConveRT models and signatures

### DIFF
--- a/tests/test_lang/test_convert_lang.py
+++ b/tests/test_lang/test_convert_lang.py
@@ -4,12 +4,60 @@ from whatlies.language import ConveRTLanguage
 
 
 @pytest.fixture
-def lang():
-    lang = ConveRTLanguage()
+def lang(request):
+    lang = ConveRTLanguage(**request.param)
     return lang
 
 
-def test_basic_docs_usage1(lang):
+@pytest.mark.parametrize(
+    "lang, expected_shape",
+    [
+        ({"model_id": "convert", "signature": "default"}, (1024,)),
+        ({"model_id": "convert", "signature": "encode_context"}, (512,)),
+        ({"model_id": "convert", "signature": "encode_response"}, (512,)),
+        ({"model_id": "convert", "signature": "encode_sequence"}, (512,)),
+        ({"model_id": "convert-multi-context", "signature": "default"}, (1024,)),
+        pytest.param(
+            {"model_id": "convert-multi-context", "signature": "encode_context"},
+            (512,),
+            marks=pytest.mark.xfail(raises=NotImplementedError),
+        ),
+        ({"model_id": "convert-multi-context", "signature": "encode_response"}, (512,)),
+        ({"model_id": "convert-multi-context", "signature": "encode_sequence"}, (512,)),
+        ({"model_id": "convert-ubuntu", "signature": "default"}, (1024,)),
+        pytest.param(
+            {"model_id": "convert-ubuntu", "signature": "encode_context"},
+            (512,),
+            marks=pytest.mark.xfail(raises=NotImplementedError),
+        ),
+        ({"model_id": "convert-ubuntu", "signature": "encode_response"}, (512,)),
+        ({"model_id": "convert-ubuntu", "signature": "encode_sequence"}, (512,)),
+    ],
+    indirect=["lang"],
+)
+def test_basic_usage(lang, expected_shape):
     embset = lang[["bank", "money on the bank", "bank of the river"]]
     assert len(embset) == 3
-    assert embset["bank"].vector.shape == (512,)
+    assert embset["bank"].vector.shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    "lang",
+    [
+        pytest.param(
+            {"model_id": "convert-context", "signature": "encode_context"},
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+        ),
+        pytest.param(
+            {"model_id": "convert", "signature": "encode"},
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+        ),
+        pytest.param(
+            {"model_id": "multi-convert", "signature": "encoded_context"},
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+        ),
+    ],
+    indirect=["lang"],
+)
+def test_invalid_argument_values_raise_error(lang):
+    pass

--- a/whatlies/language/convert_lang.py
+++ b/whatlies/language/convert_lang.py
@@ -1,8 +1,8 @@
 from typing import Union, List
+
 import tensorflow_text
 import tensorflow as tf
 import tensorflow_hub as tfhub
-
 
 from whatlies.embedding import Embedding
 from whatlies.embeddingset import EmbeddingSet
@@ -11,17 +11,23 @@ from whatlies.language.common import SklearnTransformerMixin, HiddenPrints
 
 class ConveRTLanguage(SklearnTransformerMixin):
     """
-    This object is used to lazily fetch [Embedding][whatlies.embedding.Embedding]s or
-    [EmbeddingSet][whatlies.embeddingset.EmbeddingSet]s from a keyed vector file.
-    These files are generated from [ConveRT](https://github.com/PolyAI-LDN/polyai-models).
+    This object is used to fetch [Embedding][whatlies.embedding.Embedding]s or
+    [EmbeddingSet][whatlies.embeddingset.EmbeddingSet]s from a
+    [ConveRT](https://github.com/PolyAI-LDN/polyai-models) model.
     This object is meant for retreival, not plotting.
 
     Important:
         This object will automatically download a large file if it is not cached yet.
 
-        Also note that this language model does not contain a vocabulary so it cannot be used
-        to retreive similar tokens. Instead you can create an embedding set and make do the
-        similarity query from there.
+        Also note that this language model does not contain a vocabulary, so it cannot be used
+        to retreive similar tokens. Instead, you can create an embedding set by using this model
+        and then perform similarity queries from there.
+
+    Arguments:
+        model_id: identifier used for loading the corresponding TFHub module, which could be one of `'convert`, `'convert-multi-context'` or `'convert-ubuntu'`.
+            Each one of these correspond to a different model as described in [ConveRT manual](https://github.com/PolyAI-LDN/polyai-models#models).
+        signature: the TFHub signature of the model, which could be one of `'default'`, `'encode_context'`, `'encode_response'` or `'encode_sequence'`.
+            Note that `'encode_context'` is not currently supported with `'convert-multi-context'` or `'convert-ubuntu'` models.
 
     **Usage**:
 
@@ -29,17 +35,50 @@ class ConveRTLanguage(SklearnTransformerMixin):
     > from whatlies.language import ConveRTLanguage
     > lang = ConveRTLanguage()
     > lang['bank']
-    > lang = ConveRTLanguage()
+    > lang = ConveRTLanguage(model_id='convert-multi-context', signature='encode_sequence')
     > lang[['bank of the river', 'money on the bank', 'bank']]
     ```
     """
 
-    def __init__(self):
-        with HiddenPrints():
-            module = tfhub.load("http://models.poly-ai.com/convert/v1/model.tar.gz")
-            self.model = module.signatures["encode_sequence"]
+    MODEL_URL = {
+        "convert": "http://models.poly-ai.com/convert/v1/model.tar.gz",
+        "convert-multi-context": "http://models.poly-ai.com/multi_context_convert/v1/model.tar.gz",
+        "convert-ubuntu": "http://models.poly-ai.com/ubuntu_convert/v1/model.tar.gz",
+    }
 
-    def __getitem__(self, query: Union[str, List[str]]):
+    MODEL_SIGNATURES = [
+        "default",
+        "encode_context",
+        "encode_response",
+        "encode_sequence",
+    ]
+
+    def __init__(self, model_id: str = "convert", signature: str = "default") -> None:
+        if model_id not in self.MODEL_URL:
+            raise ValueError(
+                f"The `model_id` value should be one of {list(self.MODEL_URL.keys())}"
+            )
+        if signature not in self.MODEL_SIGNATURES:
+            raise ValueError(
+                f"The `signature` value should be one of {self.MODEL_SIGNATURES}"
+            )
+        if signature == "encode_context" and model_id in [
+            "convert-multi-context",
+            "convert-ubuntu",
+        ]:
+            raise NotImplementedError(
+                "Currently 'encode_context' signature is not support with multi-context and ubuntu models."
+            )
+        self.model_id = model_id
+        self.signature = signature
+
+        with HiddenPrints():
+            self.module = tfhub.load(self.MODEL_URL[self.model_id])
+            self.model = self.module.signatures[self.signature]
+
+    def __getitem__(
+        self, query: Union[str, List[str]]
+    ) -> Union[Embedding, EmbeddingSet]:
         """
         Retreive a single embedding or a set of embeddings.
 
@@ -57,7 +96,11 @@ class ConveRTLanguage(SklearnTransformerMixin):
         ```
         """
         if isinstance(query, str):
-            tf_tensor = tf.convert_to_tensor([query])
-            vec = self.model(tf_tensor)["sequence_encoding"].numpy().sum(axis=1)[0]
+            query_tensor = tf.convert_to_tensor([query])
+            encoding = self.model(query_tensor)
+            if self.signature == "encode_sequence":
+                vec = encoding["sequence_encoding"].numpy().sum(axis=1)[0]
+            else:
+                vec = encoding["default"].numpy()[0]
             return Embedding(query, vec)
         return EmbeddingSet(*[self[tok] for tok in query])


### PR DESCRIPTION
This PR improves `ConveRTLanguage` class implementation by adding the support for different ConveRT models and signatures. It also includes the relevant tests to ensure it's working properly for different configurations (although, this comes at the cost of longer running time of tests since the models should be downloaded and are rather large).