### PR TITLE
Add Hugging Face Transformers language class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ base_packages = [
     "tensorflow==2.1.0",
     "tensorflow-text==2.1.1",
     "tensorflow-hub>=0.8.0",
+    "transformers>=3.0.0",
 ]
 
 docs_packages = [
@@ -35,6 +36,7 @@ test_packages = [
     "pytest-cov>=2.6.1",
     "nbval>=0.9.5",
     "pre-commit>=2.2.0",
+    "torch>=1.0.0",
 ]
 
 dev_packages = docs_packages + test_packages

--- a/tests/test_lang/test_hftransformers_lang.py
+++ b/tests/test_lang/test_hftransformers_lang.py
@@ -1,0 +1,62 @@
+import pytest
+import numpy as np
+from transformers import AutoTokenizer, is_tf_available, is_torch_available
+
+from whatlies.language import HFTransformersLanguage
+
+
+def load_model_and_tokenizer(model_name, tensor_type):
+    if tensor_type == "tf":
+        from transformers import TFAutoModel as AutoModel
+    elif tensor_type == "pt":
+        from transformers import AutoModel
+
+    model = AutoModel.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return model, tokenizer
+
+
+@pytest.mark.parametrize(
+    "model_name, expected_shape",
+    [
+        ("bert-base-uncased", (768,)),
+        ("gpt2", (768,)),
+        ("roberta-base", (768,)),
+        ("distilbert-base-uncased", (768,)),
+    ],
+)
+@pytest.mark.parametrize("tensor_type", ["tf", "pt"])
+def test_basic_usage_and_generated_embeddings(model_name, expected_shape, tensor_type):
+    sentences = [
+        "hello how are you?",
+        "I'm fine, thanks!",
+        "how about you?",
+    ]
+
+    model, tokenizer = load_model_and_tokenizer(model_name, tensor_type)
+    tokens = tokenizer(
+        sentences,
+        padding=True,
+        return_special_tokens_mask=True,
+        return_tensors=tensor_type,
+    )
+    mask = tokens["special_tokens_mask"].numpy()
+    del tokens["special_tokens_mask"]
+    if tensor_type == "tf":
+        output = model(tokens)
+    elif tensor_type == "pt":
+        output = model(**tokens)
+
+    lang = HFTransformersLanguage(model_name)
+    emb = lang[sentences]
+
+    assert len(emb) == len(sentences)
+    for i, s in enumerate(sentences):
+        if tensor_type == "tf":
+            feats = output[0][i][np.logical_not(mask[i])].numpy()
+        elif tensor_type == "pt":
+            feats = output[0][i][np.logical_not(mask[i])].detach().numpy()
+        assert emb[s].vector.shape == expected_shape
+        assert np.allclose(emb[s].vector, feats.sum(axis=0), atol=1e-5)

--- a/whatlies/language/__init__.py
+++ b/whatlies/language/__init__.py
@@ -6,6 +6,7 @@ from .bpemblang import BytePairLanguage
 from .bpemblang import BytePairLanguage as BytePairLang
 from .convert_lang import ConveRTLanguage
 from .gensim_lang import GensimLanguage
+from .hftransformers_lang import HFTransformersLanguage
 
 __all__ = [
     "SpacyLanguage",
@@ -16,4 +17,5 @@ __all__ = [
     "BytePairLanguage",
     "GensimLanguage",
     "ConveRTLanguage",
+    "HFTransformersLanguage",
 ]

--- a/whatlies/language/hftransformers_lang.py
+++ b/whatlies/language/hftransformers_lang.py
@@ -1,0 +1,74 @@
+from typing import List, Union, Any
+
+import numpy as np
+import transformers as trf
+
+from whatlies.embedding import Embedding
+from whatlies.embeddingset import EmbeddingSet
+
+
+class HFTransformersLanguage:
+    """
+    This language class can be used to load Hugging Face Transformer models and use them to obtain
+    representation of input string(s) as [Embedding][whatlies.embedding.Embedding] or
+    [EmbeddingSet][whatlies.embeddingset.EmbeddingSet].
+
+    Important:
+        To use this language class, either of TensorFlow or PyTorch should be installed.
+
+    Arguments:
+        model_name_or_path: A string which is the name or identifier of a model from
+            [Hugging Face model repository](https://huggingface.co/models), or is the path to a local directory
+            which contains a pre-trained transformer model files.
+        **kwargs: Additional key-value pair argument(s) which is passed to `transformers.pipeline` function.
+
+    **Usage**:
+
+    ```python
+    > from whatlies.language import HFTransformersLanguage
+    > lang = HFTransformersLanguage('bert-base-cased')
+    > lang['today is a nice day']
+    > lang = HFTransformersLanguage('gpt2')
+    > lang[['day and night', 'it is as clear as day', 'today the sky is clear']]
+    ```
+    """
+
+    def __init__(self, model_name_or_path: str, **kwargs: Any) -> None:
+        self.model = trf.pipeline(
+            task="feature-extraction", model=model_name_or_path, **kwargs
+        )
+
+    def __getitem__(self, query: Union[str, List[str]]):
+        """
+        Retreive a single embedding or a set of embeddings.
+
+        Arguments:
+            query: A single string or a list of strings
+
+        Returns:
+            An instance of [Embedding][whatlies.embedding.Embedding] (when `query` is a string)
+            or [EmbeddingSet][whatlies.embeddingset.EmbeddingSet] (when `query` is a list of strings).
+            The embedding vector is computed as the sum of hidden-state representaions of tokens
+            (excluding special tokens, e.g. [CLS]).
+
+        **Usage**
+
+        ```python
+        > from whatlies.language import HFTransformersLanguage
+        > lang = HFTransformersLanguage('bert-base-cased')
+        > lang['today is a nice day']
+        > lang = HFTransformersLanguage('gpt2')
+        > lang[['day and night', 'it is as clear as day', 'today the sky is clear']]
+        ```
+        """
+        if isinstance(query, str):
+            return self._get_embedding(query)
+        return EmbeddingSet(*[self._get_embedding(q) for q in query])
+
+    def _get_embedding(self, query: str):
+        features = np.array(self.model(query, padding=False)[0])
+        special_tokens_mask = self.model.tokenizer(
+            query, return_special_tokens_mask=True, return_tensors="np"
+        )["special_tokens_mask"][0]
+        vec = features[np.logical_not(special_tokens_mask)].sum(axis=0)
+        return Embedding(query, vec)


### PR DESCRIPTION
This PR addresses #12 and implements `HFTransformersLanguage` class to support Hugging Face Transformer models. It's an initial implementation, with room for adding more features and custom configs. Currently, the embedding vector is obtained by summing the token representations (excluding special tokens, e.g. [CLS] or [SEP]).

Further, we have added `torch` as a **development dependency** so that we can test this class on both TensorFlow as well as PyTorch.