### PR TITLE
Fix incorrect embedding bug in spaCy language class

### DIFF
--- a/tests/test_lang/test_spacy_language.py
+++ b/tests/test_lang/test_spacy_language.py
@@ -4,7 +4,59 @@ import numpy as np
 from spacy.vocab import Vocab
 from spacy.language import Language
 from whatlies.language import SpacyLanguage
-from whatlies.language.spacy_lang import _selected_idx_spacy
+
+
+@pytest.fixture(scope="module")
+def lang():
+    return SpacyLanguage("en_core_web_md")
+
+
+def test_basic_usage(lang):
+    queries = [
+        "yesterday is history",
+        "tomorrow is mystery",
+        "today is a gift",
+        "that's why it's called [present]",
+    ]
+    emb = lang[queries]
+    assert len(emb) == 4
+    assert emb[queries[0]].name == "yesterday is history"
+    assert emb[queries[0]].vector.shape == (300,)
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["no [closing bracket", "no opening] bracket", "[more] than one [context]",],
+)
+def test_invalid_query_raises_error(lang, query):
+    with pytest.raises(ValueError, match="bracket"):
+        lang[query]
+
+
+@pytest.mark.parametrize(
+    "query, context, context_pos",
+    [
+        ("I'm going [home]", "home", (3, 4)),
+        ("you should pre-order your [washing machine]", "washing machine", (6, 8)),
+        ("today is the [best day] of my life", "best day", (3, 5)),
+        ("[yesterday] isn't mystery", "yesterday", (0, 1)),
+        (
+            "Let's have Fun without context.",
+            "Let's have Fun without context.",
+            (0, None),
+        ),
+    ],
+)
+def test_embedding_is_correct(lang, query, context, context_pos):
+    emb = lang[query]
+    assert emb.vector.shape == (300,)
+    assert emb.name == query
+
+    clean_query = query.replace("[", "").replace("]", "")
+    doc = lang.model(clean_query)
+    span = doc[context_pos[0] : context_pos[1]]
+    assert str(span) == context
+    assert np.allclose(emb.vector, span.vector)
 
 
 @pytest.fixture()
@@ -44,23 +96,10 @@ def test_lang_retreival(color_lang, string, array):
 
 def test_single_token_words(color_lang):
     # test for issue here: https://github.com/RasaHQ/whatlies/issues/5
-    assert np.sum(color_lang["red"].vector) > 0
+    assert len(color_lang["red"].vector) > 0
 
 
 def test_raise_warning(color_lang):
     print([w for w in color_lang.nlp.vocab])
     with pytest.warns(UserWarning):
         color_lang.score_similar("red", 100, prob_limit=None, lower=False)
-
-
-@pytest.mark.parametrize(
-    "triplets",
-    zip(
-        ["red", "red green", "red green [blue] purple", "red [green blue] pink"],
-        [0, 0, 2, 1],
-        [1, 2, 3, 3],
-    ),
-)
-def test_select_idx_func(triplets):
-    string, start, end = triplets
-    assert _selected_idx_spacy(string) == (start, end)

--- a/tests/test_lang/test_spacy_language.py
+++ b/tests/test_lang/test_spacy_language.py
@@ -6,59 +6,6 @@ from spacy.language import Language
 from whatlies.language import SpacyLanguage
 
 
-@pytest.fixture(scope="module")
-def lang():
-    return SpacyLanguage("en_core_web_md")
-
-
-def test_basic_usage(lang):
-    queries = [
-        "yesterday is history",
-        "tomorrow is mystery",
-        "today is a gift",
-        "that's why it's called [present]",
-    ]
-    emb = lang[queries]
-    assert len(emb) == 4
-    assert emb[queries[0]].name == "yesterday is history"
-    assert emb[queries[0]].vector.shape == (300,)
-
-
-@pytest.mark.parametrize(
-    "query",
-    ["no [closing bracket", "no opening] bracket", "[more] than one [context]",],
-)
-def test_invalid_query_raises_error(lang, query):
-    with pytest.raises(ValueError, match="bracket"):
-        lang[query]
-
-
-@pytest.mark.parametrize(
-    "query, context, context_pos",
-    [
-        ("I'm going [home]", "home", (3, 4)),
-        ("you should pre-order your [washing machine]", "washing machine", (6, 8)),
-        ("today is the [best day] of my life", "best day", (3, 5)),
-        ("[yesterday] isn't mystery", "yesterday", (0, 1)),
-        (
-            "Let's have Fun without context.",
-            "Let's have Fun without context.",
-            (0, None),
-        ),
-    ],
-)
-def test_embedding_is_correct(lang, query, context, context_pos):
-    emb = lang[query]
-    assert emb.vector.shape == (300,)
-    assert emb.name == query
-
-    clean_query = query.replace("[", "").replace("]", "")
-    doc = lang.model(clean_query)
-    span = doc[context_pos[0] : context_pos[1]]
-    assert str(span) == context
-    assert np.allclose(emb.vector, span.vector)
-
-
 @pytest.fixture()
 def color_lang():
     vector_data = {
@@ -73,6 +20,58 @@ def color_lang():
         vocab.set_vector(word, vector)
     nlp = Language(vocab=vocab)
     return SpacyLanguage(nlp)
+
+
+def test_basic_usage(color_lang):
+    queries = [
+        "green is blue and yellow",
+        "purple is red and blue",
+        "purple isn't same as red!",
+        "[red and blue] is a like a glue!",
+    ]
+    emb = color_lang[queries]
+    assert len(emb) == 4
+    assert emb[queries[0]].name == "green is blue and yellow"
+    assert emb[queries[0]].vector.shape == (2,)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "no blue [closing bracket",
+        "no red opening] bracket",
+        "[more] than one blue [context]",
+    ],
+)
+def test_invalid_query_raises_error(color_lang, query):
+    with pytest.raises(ValueError, match="bracket"):
+        color_lang[query]
+
+
+@pytest.mark.parametrize(
+    "query, context, context_pos",
+    [
+        ("I'm going [blue]", "blue", (2, 3)),
+        ("you should pre-order your [red shirt]", "red shirt", (6, 8)),
+        ("Me: today is the [best green day] of my life", "best green day", (5, 8)),
+        ("[red and blue] is like a glue!", "red and blue", (0, 3)),
+        (
+            "Let's have Fun without a blue context.",
+            "Let's have Fun without a blue context.",
+            (0, None),
+        ),
+    ],
+)
+def test_embedding_is_correct(color_lang, query, context, context_pos):
+    emb = color_lang[query]
+    assert emb.vector.shape == (2,)
+    assert emb.name == query
+
+    clean_query = query.replace("[", "").replace("]", "")
+    doc = color_lang.model(clean_query)
+    span = doc[context_pos[0] : context_pos[1]]
+    assert str(span) == context
+    assert np.allclose(emb.vector, span.vector)
 
 
 def test_score_similar_one(color_lang):


### PR DESCRIPTION
This PR is a (temporary) fix for issue #91 which resulted from doing tokenization based on whitespace. I thought this was important to be fixed (until we find a better solution) because, as discussed in #91, even for some sentences (and languages with no space, such as Japanese) where there is no requested context embedding, the result is wrong as well.

@koaning I have used `en_core_web_md` model in the tests so that we could have better and more reliable real use-case tests. However, I did not add the installation command to Github actions config file yet (that's why the tests are failing) because I don't know if you are agreed with this or not. Let me know if you are OK with this, and I'll add another commit to this PR for that.