### PR TITLE
Add axis_option argument for matplotlib plots

### DIFF
--- a/whatlies/common.py
+++ b/whatlies/common.py
@@ -14,6 +14,7 @@ def handle_2d_plot(
     ylabel=None,
     show_operations=False,
     annot=False,
+    axis_option=None,
 ):
     """
     Handles the logic to perform a 2d plot in matplotlib.
@@ -26,6 +27,7 @@ def handle_2d_plot(
     - xlabel: manually override the xlabel
     - ylabel: manually override the ylabel
     - show_operations: setting to also show the applied operations, only works for `text`
+    - axis_option: a string which is passed to `matplotlib.pyplot.axis` function.
     """
     name = embedding.name if show_operations else embedding.orig
     if kind == "scatter":
@@ -50,6 +52,8 @@ def handle_2d_plot(
 
     plt.xlabel("x" if not xlabel else xlabel)
     plt.ylabel("y" if not ylabel else ylabel)
+    if axis_option is not None:
+        plt.axis(axis_option)
 
 
 def plot_graph_layout(embedding_set, kind="cosine", **kwargs):

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 from copy import deepcopy
 
 import numpy as np
@@ -183,6 +183,7 @@ class Embedding:
         color: str = None,
         show_ops: bool = False,
         annot: bool = False,
+        axis_option: Optional[str] = None,
     ):
         """
         Handles the logic to perform a 2d plot in matplotlib.
@@ -194,6 +195,11 @@ class Embedding:
             color: the color of the dots
             show_ops: setting to also show the applied operations, only works for `text`
             annot: should the points be annotated
+            axis_option: a string which is passed as `option` argument to `matplotlib.pyplot.axis` in order to control
+                axis properties (e.g. using `'equal'` make circles shown circular in the plot). This might be useful
+                for preserving geometric relationships (e.g. orthogonality) in the generated plot. See `matplotlib.pyplot.axis`
+                [documentation](https://matplotlib.org/3.1.0/api/_as_gen/matplotlib.pyplot.axis.html#matplotlib-pyplot-axis)
+                for possible values and their description.
 
         **Usage**
         ```python
@@ -215,6 +221,7 @@ class Embedding:
                 xlabel=x_axis,
                 ylabel=y_axis,
                 annot=annot,
+                axis_option=axis_option,
             )
             return self
         x_val = self > x_axis
@@ -228,5 +235,6 @@ class Embedding:
             ylabel=y_axis.name,
             show_operations=show_ops,
             annot=annot,
+            axis_option=axis_option,
         )
         return self

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -497,6 +497,7 @@ class EmbeddingSet:
             y_axis: the y-axis to be used, must be given when dim > 2
             color: the color of the dots
             show_ops: setting to also show the applied operations, only works for `text`
+            kwargs: additional key-value pair arguments which are passed to `plot` method of `Embedding` class
         """
         for k, token in self.embeddings.items():
             token.plot(


### PR DESCRIPTION
This PR addresses #38 for matplotlib plots (i.e. `plot` method of `Embedding` and `EmbeddingSet`).