### PR TITLE
Fix bug in score_similar method of EmbeddingSet

### DIFF
--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -403,12 +403,11 @@ class EmbeddingSet:
                 f"You cannot retreive (n={n}) more items than exist in the Embeddingset (len={len(self)})"
             )
 
-        if str(emb) not in self.embeddings.keys():
-            raise ValueError(
-                f"Embedding for `{str(emb)}` does not exist in this EmbeddingSet"
-            )
-
         if isinstance(emb, str):
+            if emb not in self.embeddings.keys():
+                raise ValueError(
+                    f"Embedding for `{emb}` does not exist in this EmbeddingSet"
+                )
             emb = self[emb]
 
         vec = emb.vector


### PR DESCRIPTION
The following raises an error:

```python
foo = Embedding('foo',...)
bar = Embedding('bar',...)
baz = Embedding('baz',...)

embset = EmbeddingSet(foo, bar)
embset.score_similar(baz, n=2)

> ValueError: Embedding for `baz` does not exist in this EmbeddingSet
```

Only if the given embedding is a string it should be checked whether it exists in `EmbeddingSet` or not. Otherwise, an `Embedding` instance is always allowed.