### PR TITLE
Fix #101 - update SpacyLanguage class to support spaCy v2.3+ models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ base_packages = [
     "altair>=4.0.1",
     "matplotlib>=3.2.0",
     "spacy>=2.2.3",
+    "spacy-lookups-data>=0.3.2",
     "networkx>=2.4",
     "sense2vec>=1.0.2",
     "fasttext>=0.9.1",


### PR DESCRIPTION
As the title says. However, there are two additional points:

- Instead of loading all the vocab when instantiating the class (i.e. in `__init__` method), I decided to implement a separate method for this in order to comply with the  original goal of spaCy maintainers which is reducing the loading time of the model (in this library, this point is useful when the user only want to get embeddings from the model, and not doing something like similarity search). Although, in this implementation, this reduction may come at the annoyance of calling `self._load_vocab` method every time we want to iterate over `vocab` in the code (which currently happens only once).

- I have not included a spaCy model (e.g. `en_core_web_md`) in the tests yet, until it's decided how to go about this; however, I tested the class manually after modifications and it's working properly.