### PR TITLE
Reduce Ivis Bugs during Testing

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -46,4 +46,4 @@ jobs:
     - name: Test with pytest
       run: |
         python tests/prepare_fasttext_tests.py
-        pytest --verbose
+        pytest --verbose --durations 0

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -22,9 +22,9 @@ transformers = [
     lambda d: d | (d["man"] - d["woman"]),
     Tsne(2, n_iter=250),
     Tsne(3, n_iter=250),
-    OpenTsne(2, n_iter=10),
-    Ivis(2, k=10, batch_size=10),
-    Ivis(3, k=10, batch_size=10),
+    OpenTsne(2, n_iter=2),
+    Ivis(2, k=10, batch_size=10, epochs=10),
+    Ivis(3, k=10, batch_size=10, epochs=10),
 ]
 extra_sizes = [2, 3, 2, 3, 0, 0, 4, 1, 0, 2, 3, 2, 2, 3]
 tfm_ids = [_.__class__.__name__ for _ in transformers]
@@ -45,7 +45,7 @@ def test_transformations_new_size(transformer, extra_size):
         Pca(2),
         Noise(0.1),
         Tsne(2, n_iter=250),
-        OpenTsne(2, n_iter=10),
+        OpenTsne(2, n_iter=1),
         Ivis(2, k=10, batch_size=10),
         AddRandom(n=4),
         lambda d: d | (d["man"] - d["woman"]),


### PR DESCRIPTION
I reduced the number of `epochs` that Ivis is using during testing. That should help with some of the flaky tests. 

I also ran a benchmark on that file with pytest locally. 

```
> pytest tests/test_transformers.py --durations 0
16.48s call     tests/test_transformers.py::test_transformations_new_size[OpenTsne]
15.63s call     tests/test_transformers.py::test_transformations_keep_props[transformer4]
6.96s call     tests/test_transformers.py::test_transformations_new_size[Umap0]
2.06s call     tests/test_transformers.py::test_transformations_keep_props[transformer5]
1.97s call     tests/test_transformers.py::test_transformations_keep_props[transformer0]
1.91s call     tests/test_transformers.py::test_transformations_new_size[Ivis1]
1.90s call     tests/test_transformers.py::test_transformations_new_size[Ivis0]
1.73s call     tests/test_transformers.py::test_transformations_new_size[Umap1]
0.23s call     tests/test_transformers.py::test_transformations_new_size[Tsne0]
0.12s call     tests/test_transformers.py::test_transformations_new_size[Tsne1]
0.11s call     tests/test_transformers.py::test_transformations_keep_props[transformer3]
```

It still seems like OpenTsne is super slow despite what the [docs say](https://opentsne.readthedocs.io/en/latest/benchmarks.html).