### PR TITLE
Fix #128 - Use 'EmbSet' as the default name of EmbeddingSet

### DIFF
--- a/tests/test_embeddingset.py
+++ b/tests/test_embeddingset.py
@@ -41,7 +41,7 @@ def test_merge_basic(lang):
 def test_average(lang):
     emb = lang[["red", "blue", "orange"]]
     av = emb.average()
-    assert av.name == "Emb.average()"
+    assert av.name == "EmbSet.average()"
     v1 = av.vector
     v2 = (lang["red"].vector + lang["blue"].vector + lang["orange"].vector) / 3
     assert np.array_equal(v1, v2)

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -39,7 +39,7 @@ class EmbeddingSet:
 
     def __init__(self, *embeddings, name=None):
         if not name:
-            name = "Emb"
+            name = "EmbSet"
         self.name = name
         if len(embeddings) == 1:
             # we assume it is a dictionary here


### PR DESCRIPTION
Fixes #128, as the title says.