### PR TITLE
[WIP] Add support for integer axis as well as setting axis label and title in plot method

### DIFF
--- a/whatlies/common.py
+++ b/whatlies/common.py
@@ -12,6 +12,7 @@ def handle_2d_plot(
     color=None,
     xlabel=None,
     ylabel=None,
+    title=None,
     show_operations=False,
     annot=False,
     axis_option=None,
@@ -26,6 +27,7 @@ def handle_2d_plot(
     - color: the color to apply, only works for `scatter` and `arrow`
     - xlabel: manually override the xlabel
     - ylabel: manually override the ylabel
+    - title: optional title used for the plot
     - show_operations: setting to also show the applied operations, only works for `text`
     - axis_option: a string which is passed to `matplotlib.pyplot.axis` function.
     """
@@ -50,8 +52,10 @@ def handle_2d_plot(
     if (kind == "text") or annot:
         plt.text(embedding.vector[0] + 0.01, embedding.vector[1], name)
 
-    plt.xlabel("x" if not xlabel else xlabel)
-    plt.ylabel("y" if not ylabel else ylabel)
+    plt.xlabel("x" if xlabel is None else xlabel)
+    plt.ylabel("y" if ylabel is None else ylabel)
+    if title is not None:
+        plt.title(title)
     if axis_option is not None:
         plt.axis(axis_option)
 

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 from copy import deepcopy
 from functools import reduce
 
@@ -513,8 +513,11 @@ class EmbeddingSet:
     def plot(
         self,
         kind: str = "scatter",
-        x_axis: str = None,
-        y_axis: str = None,
+        x_axis: Union[int, str, Embedding] = None,
+        y_axis: Union[int, str, Embedding] = None,
+        x_label: Optional[str] = None,
+        y_label: Optional[str] = None,
+        title: Optional[str] = None,
         color: str = None,
         show_ops: str = False,
         **kwargs,
@@ -524,17 +527,29 @@ class EmbeddingSet:
 
         Arguments:
             kind: what kind of plot to make, can be `scatter`, `arrow` or `text`
-            x_axis: the x-axis to be used, must be given when dim > 2
-            y_axis: the y-axis to be used, must be given when dim > 2
+            x_axis: the x-axis to be used, must be given when dim > 2; if an integer, the corresponding
+                dimension of embedding is used.
+            y_axis: the y-axis to be used, must be given when dim > 2; if an integer, the corresponding
+                dimension of embedding is used.
+            x_label: an optional label used for x-axis; if not given, it is set based on value of `x_axis`.
+            y_label: an optional label used for y-axis; if not given, it is set based on value of `y_axis`.
+            title: an optional title for the plot.
             color: the color of the dots
             show_ops: setting to also show the applied operations, only works for `text`
             kwargs: additional key-value pair arguments which are passed to `plot` method of `Embedding` class
         """
+        if isinstance(x_axis, str):
+            x_axis = self[x_axis]
+        if isinstance(y_axis, str):
+            y_axis = self[y_axis]
         for k, token in self.embeddings.items():
             token.plot(
                 kind=kind,
                 x_axis=x_axis,
                 y_axis=y_axis,
+                x_label=x_label,
+                y_label=y_label,
+                title=title,
                 color=color,
                 show_ops=show_ops,
                 **kwargs,


### PR DESCRIPTION
This PR addresses both issues #125 and #127 for matplotlib plots (i.e. `plot` method of `Embedding` and `EmbeddingSet`). The tests will be added.
Although, I am not satisfied with the way that `handle_2d_plot` function works; it only accepts an `Embedding` instance and therefore in `plot` method of `EmbeddingSet` things like determining axis is unnecessarily done over and over. I think there is room for improvement there. Further, this PR may address the issue #140.

**Backwards incompatible changes**:
- If `foo` is a 2D embedding, previously running `foo.plot(x_axis='xx', y_axis='yy')` was possible. Now, in `Embedding.plot` method, `x_axis` and `y_axis` can only take values of type integer or `Embedding`. In this case, to recreate the same plot as before, `x_label` and `y_label` arguments should be used instead.

**Bugs this PR resolve:**
- Previously, if `emb` was an embedding set (with dim > 2) and `'foo'` and `'bar'` were members of it, running `emb.plot(x_axis='foo', y_axis='bar')` would raise an error. This is resolved now.
- Previously if `foo`, `bar` and `buz` were all 2D embeddings, running `foo.plot(x_axis=bar, y_axis=buz)` would ignore `bar` and `buz` and plot the `foo` embedding itself (i.e. without projecting it onto `bar` and `buz`).