### PR TITLE
Reduce Ivis epochs in tests

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -46,7 +46,7 @@ def test_transformations_new_size(transformer, extra_size):
         Noise(0.1),
         Tsne(2, n_iter=250),
         OpenTsne(2, n_iter=1),
-        Ivis(2, k=10, batch_size=10),
+        Ivis(2, k=10, batch_size=10, epochs=10),
         AddRandom(n=4),
         lambda d: d | (d["man"] - d["woman"]),
     ],


### PR DESCRIPTION
The automated tests for the last push [were failed](https://github.com/RasaHQ/whatlies/runs/986783620) after 5+ hours due to the Ivis not converging (as known before). This PR fixes another instance.