### PR TITLE
Make the Embedding.plot() method use `arrow` as a standard. 

### DIFF
--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -177,7 +177,7 @@ class Embedding:
 
     def plot(
         self,
-        kind: str = "scatter",
+        kind: str = "arrow",
         x_axis: Union[str, "Embedding"] = None,
         y_axis: Union[str, "Embedding"] = None,
         color: str = None,


### PR DESCRIPTION
My gut feeling is that the main utility for the `.plot()` method on the `Embedding` object is that we can easily demonstrate how this package allows for arithmetic. That means that the chart is educational in nature. It also means that we might favor `arrow` as a default argument over `scatter`. 

This is a breaking change, so we should not immediately do this change without discussion. I've created this PR as a place to discuss it and I won't merge unless I've hear another opinion on this. 

@mkaze do you have a strong opinion on this? 