### PR TITLE
Fix #154 - Add base class for transformers

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -2,7 +2,16 @@ import pytest
 from spacy.vocab import Vocab
 from spacy.language import Language
 from whatlies.language import SpacyLanguage
-from whatlies.transformers import Umap, Pca, Noise, AddRandom, Tsne, OpenTsne, Ivis
+from whatlies.transformers import (
+    Transformer,
+    Umap,
+    Pca,
+    Noise,
+    AddRandom,
+    Tsne,
+    OpenTsne,
+    Ivis,
+)
 
 
 vocab = Vocab().from_disk("tests/custom_test_vocab/")
@@ -55,3 +64,24 @@ def test_transformations_keep_props(transformer):
     emb_new = emb.add_property("group", lambda d: "one").transform(transformer)
     for w in words:
         assert hasattr(emb_new[w], "group")
+
+
+@pytest.mark.parametrize(
+    "transformer",
+    [
+        Umap(2),
+        Pca(2),
+        Noise(0.1),
+        AddRandom(n=4),
+        Tsne(2, n_iter=250),
+        OpenTsne(2, n_iter=2),
+        Ivis(2, k=10, batch_size=10, epochs=10),
+    ],
+)
+def test_transformers_are_subclassed_properly(transformer):
+    assert isinstance(transformer, Transformer)
+
+
+def test_transformer_base_class():
+    with pytest.raises(TypeError, match="Can't instantiate abstract class Transformer"):
+        Transformer()

--- a/whatlies/transformers/__init__.py
+++ b/whatlies/transformers/__init__.py
@@ -1,3 +1,4 @@
+from whatlies.transformers.transformer import Transformer
 from whatlies.transformers.pca import Pca
 from whatlies.transformers.umap import Umap
 from whatlies.transformers.noise import Noise
@@ -15,4 +16,13 @@ try:
 except ModuleNotFoundError:
     Ivis = NotInstalled("Ivis", "ivis")
 
-__all__ = ["Pca", "Umap", "Noise", "AddRandom", "Tsne", "OpenTsne", "Ivis"]
+__all__ = [
+    "Transformer",
+    "Pca",
+    "Umap",
+    "Noise",
+    "AddRandom",
+    "Tsne",
+    "OpenTsne",
+    "Ivis",
+]

--- a/whatlies/transformers/addrandom.py
+++ b/whatlies/transformers/addrandom.py
@@ -1,10 +1,11 @@
 import numpy as np
 
+from whatlies.transformers import Transformer
 from whatlies import Embedding, EmbeddingSet
 from whatlies.transformers.common import embset_to_X
 
 
-class AddRandom:
+class AddRandom(Transformer):
     """
     This transformer adds random embeddings to the embeddingset.
 
@@ -34,11 +35,6 @@ class AddRandom:
         self.sigma = sigma
         self.seed = seed
         self.is_fitted = False
-
-    def __call__(self, embset):
-        if not self.is_fitted:
-            self.fit(embset)
-        return self.transform(embset)
 
     def fit(self, embset):
         embset_to_X(embset=embset)

--- a/whatlies/transformers/addrandom.py
+++ b/whatlies/transformers/addrandom.py
@@ -31,10 +31,10 @@ class AddRandom(Transformer):
     """
 
     def __init__(self, n=1, sigma=0.1, seed=42):
+        super().__init__()
         self.n = n
         self.sigma = sigma
         self.seed = seed
-        self.is_fitted = False
 
     def fit(self, embset):
         embset_to_X(embset=embset)

--- a/whatlies/transformers/ivis.py
+++ b/whatlies/transformers/ivis.py
@@ -1,3 +1,4 @@
+from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
 from whatlies.transformers.common import embset_to_X, new_embedding_dict
 
@@ -5,7 +6,7 @@ from ivis import Ivis as IVIS
 import numpy as np
 
 
-class Ivis:
+class Ivis(Transformer):
     """
     This transformer scales all the vectors in an [EmbeddingSet][whatlies.embeddingset.EmbeddingSet]
     by means of Ivis algorithm. We're using the implementation found
@@ -47,11 +48,6 @@ class Ivis:
         self.kwargs = kwargs
         self.kwargs["verbose"] = 0
         self.tfm = IVIS(embedding_dims=self.n_components, **self.kwargs)
-
-    def __call__(self, embset):
-        if not self.is_fitted:
-            self.fit(embset)
-        return self.transform(embset)
 
     def fit(self, embset):
         names, X = embset_to_X(embset=embset)

--- a/whatlies/transformers/ivis.py
+++ b/whatlies/transformers/ivis.py
@@ -43,7 +43,7 @@ class Ivis(Transformer):
     """
 
     def __init__(self, n_components=2, **kwargs):
-        self.is_fitted = False
+        super().__init__()
         self.n_components = n_components
         self.kwargs = kwargs
         self.kwargs["verbose"] = 0

--- a/whatlies/transformers/noise.py
+++ b/whatlies/transformers/noise.py
@@ -33,7 +33,7 @@ class Noise(Transformer):
     """
 
     def __init__(self, sigma=0.1, seed=42):
-        self.is_fitted = False
+        super().__init__()
         self.seed = seed
         self.tfm = FunctionTransformer(
             lambda X: X + np.random.normal(0, sigma, X.shape)

--- a/whatlies/transformers/noise.py
+++ b/whatlies/transformers/noise.py
@@ -1,11 +1,12 @@
 import numpy as np
 from sklearn.preprocessing import FunctionTransformer
 
+from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
 from whatlies.transformers.common import embset_to_X, new_embedding_dict
 
 
-class Noise:
+class Noise(Transformer):
     """
     This transformer adds gaussian noise to an embeddingset.
 
@@ -37,11 +38,6 @@ class Noise:
         self.tfm = FunctionTransformer(
             lambda X: X + np.random.normal(0, sigma, X.shape)
         )
-
-    def __call__(self, embset):
-        if not self.is_fitted:
-            self.fit(embset)
-        return self.transform(embset)
 
     def fit(self, embset):
         names, X = embset_to_X(embset=embset)

--- a/whatlies/transformers/opentsne.py
+++ b/whatlies/transformers/opentsne.py
@@ -47,7 +47,7 @@ class OpenTsne(Transformer):
     """
 
     def __init__(self, n_components=2, **kwargs):
-        self.is_fitted = False
+        super().__init__()
         self.n_components = n_components
         self.kwargs = kwargs
         self.tfm = TSNE(n_components=n_components, **kwargs)

--- a/whatlies/transformers/opentsne.py
+++ b/whatlies/transformers/opentsne.py
@@ -1,11 +1,12 @@
 import numpy as np
 from openTSNE import TSNE
 
+from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
 from whatlies.transformers.common import embset_to_X, new_embedding_dict
 
 
-class OpenTsne:
+class OpenTsne(Transformer):
     """
     This transformer transformers all vectors in an [EmbeddingSet][whatlies.embeddingset.EmbeddingSet]
     by means of tsne. This implementation used
@@ -50,12 +51,6 @@ class OpenTsne:
         self.n_components = n_components
         self.kwargs = kwargs
         self.tfm = TSNE(n_components=n_components, **kwargs)
-
-    def __call__(self, embset):
-        if not self.is_fitted:
-            self.fit(embset)
-            self.is_fitted = True
-        return self.transform(embset)
 
     def fit(self, embset):
         names, X = embset_to_X(embset=embset)

--- a/whatlies/transformers/pca.py
+++ b/whatlies/transformers/pca.py
@@ -1,11 +1,12 @@
 import numpy as np
 from sklearn.decomposition import PCA
 
+from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
 from whatlies.transformers.common import embset_to_X, new_embedding_dict
 
 
-class Pca:
+class Pca(Transformer):
     """
     This transformer scales all the vectors in an [EmbeddingSet][whatlies.embeddingset.EmbeddingSet]
     by means of principal component analysis. We're using the implementation found in
@@ -38,11 +39,6 @@ class Pca:
         self.n_components = n_components
         self.kwargs = kwargs
         self.tfm = PCA(n_components=n_components)
-
-    def __call__(self, embset):
-        if not self.is_fitted:
-            self.fit(embset)
-        return self.transform(embset)
 
     def fit(self, embset):
         names, X = embset_to_X(embset=embset)

--- a/whatlies/transformers/pca.py
+++ b/whatlies/transformers/pca.py
@@ -35,7 +35,7 @@ class Pca(Transformer):
     """
 
     def __init__(self, n_components=2, **kwargs):
-        self.is_fitted = False
+        super().__init__()
         self.n_components = n_components
         self.kwargs = kwargs
         self.tfm = PCA(n_components=n_components)

--- a/whatlies/transformers/transformer.py
+++ b/whatlies/transformers/transformer.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+
+from whatlies import EmbeddingSet
+
+
+class Transformer(ABC):
+    """
+    This is the abstract base class for all the transformers. Each subclass of
+    this class should at least implement the `fit` and `transform` methods.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.is_fitted = False
+
+    def __call__(self, embset: EmbeddingSet) -> EmbeddingSet:
+        if not self.is_fitted:
+            self.fit(embset)
+        return self.transform(embset)
+
+    @abstractmethod
+    def fit(self, embset: EmbeddingSet) -> "Transformer":
+        """
+        Fit the transformer on the given `EmbeddingSet` instance (if neccessary). This method should
+        set the `is_fitted` flag to `True`.
+
+        Arguments:
+            embset: an `EmbeddingSet` instance used for fitting the transformer.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def transform(self, embset: EmbeddingSet) -> EmbeddingSet:
+        """
+        Transform the given `EmbeddingSet` instance.
+
+        Arguments:
+            embset: an `EmbeddingSet` instance to be transformed.
+        """
+        raise NotImplementedError

--- a/whatlies/transformers/tsne.py
+++ b/whatlies/transformers/tsne.py
@@ -39,7 +39,7 @@ class Tsne(Transformer):
     """
 
     def __init__(self, n_components=2, **kwargs):
-        self.is_fitted = False
+        super().__init__()
         self.n_components = n_components
         self.kwargs = kwargs
         self.tfm = TSNE(n_components=n_components, **kwargs)

--- a/whatlies/transformers/tsne.py
+++ b/whatlies/transformers/tsne.py
@@ -1,11 +1,12 @@
 import numpy as np
 from sklearn.manifold import TSNE
 
+from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
 from whatlies.transformers.common import embset_to_X, new_embedding_dict
 
 
-class Tsne:
+class Tsne(Transformer):
     """
     This transformer transformers all vectors in an [EmbeddingSet][whatlies.embeddingset.EmbeddingSet]
     by means of tsne. This implementation uses
@@ -42,11 +43,6 @@ class Tsne:
         self.n_components = n_components
         self.kwargs = kwargs
         self.tfm = TSNE(n_components=n_components, **kwargs)
-
-    def __call__(self, embset):
-        if not self.is_fitted:
-            self.fit(embset)
-        return self.transform(embset)
 
     def fit(self, embset):
         names, X = embset_to_X(embset=embset)

--- a/whatlies/transformers/umap.py
+++ b/whatlies/transformers/umap.py
@@ -4,11 +4,12 @@ from umap import UMAP
 import numpy as np
 from numba import NumbaPerformanceWarning
 
+from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
 from whatlies.transformers.common import embset_to_X, new_embedding_dict
 
 
-class Umap:
+class Umap(Transformer):
     """
     This transformer transformers all vectors in an [EmbeddingSet][whatlies.embeddingset.EmbeddingSet]
     by means of umap. We're using the implementation in [umap-learn](https://umap-learn.readthedocs.io/en/latest/).
@@ -40,11 +41,6 @@ class Umap:
         self.n_components = n_components
         self.kwargs = kwargs
         self.tfm = UMAP(n_components=n_components, **kwargs)
-
-    def __call__(self, embset):
-        if not self.is_fitted:
-            self.fit(embset)
-        return self.transform(embset)
 
     def fit(self, embset):
         names, X = embset_to_X(embset=embset)

--- a/whatlies/transformers/umap.py
+++ b/whatlies/transformers/umap.py
@@ -37,7 +37,7 @@ class Umap(Transformer):
     """
 
     def __init__(self, n_components=2, **kwargs):
-        self.is_fitted = False
+        super().__init__()
         self.n_components = n_components
         self.kwargs = kwargs
         self.tfm = UMAP(n_components=n_components, **kwargs)


### PR DESCRIPTION
This PR fixes #154 by adding an abstract base class for transformers and also performing some refactoring (i.e. removing `__call__` method implementation from subclasses).