### PR TITLE
Add missing spacy model to croncheck

### DIFF
--- a/.github/workflows/croncheck.yml
+++ b/.github/workflows/croncheck.yml
@@ -24,6 +24,7 @@ jobs:
         pip install -e ".[dev]"
         pip install flake8 pytest black
         python -m spacy download en_core_web_sm
+        python -m spacy download en_core_web_md
     - name: Style Check
       run: |
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
The scheduled tests [are failing](https://github.com/RasaHQ/whatlies/actions?query=workflow%3A%22Cron+Test+Dependencies%22) due to this.