### PR TITLE
Refactor transformers - replace embset_to_X with to_names_X

### DIFF
--- a/whatlies/transformers/addrandom.py
+++ b/whatlies/transformers/addrandom.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from whatlies.transformers import Transformer
 from whatlies import Embedding, EmbeddingSet
-from whatlies.transformers.common import embset_to_X
 
 
 class AddRandom(Transformer):
@@ -37,12 +36,11 @@ class AddRandom(Transformer):
         self.seed = seed
 
     def fit(self, embset):
-        embset_to_X(embset=embset)
         self.is_fitted = True
         return self
 
     def transform(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         np.random.seed(self.seed)
         orig_dict = embset.embeddings.copy()
         new_dict = {

--- a/whatlies/transformers/common.py
+++ b/whatlies/transformers/common.py
@@ -1,14 +1,6 @@
 from copy import deepcopy
 
-import numpy as np
-
 from whatlies import Embedding
-
-
-def embset_to_X(embset):
-    names = list(embset.embeddings.keys())
-    embs = np.array([i.vector for i in embset.embeddings.values()])
-    return names, embs
 
 
 def new_embedding_dict(names_new, vectors_new, old_embset):

--- a/whatlies/transformers/ivis.py
+++ b/whatlies/transformers/ivis.py
@@ -1,6 +1,6 @@
 from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
-from whatlies.transformers.common import embset_to_X, new_embedding_dict
+from whatlies.transformers.common import new_embedding_dict
 
 from ivis import Ivis as IVIS
 import numpy as np
@@ -50,13 +50,13 @@ class Ivis(Transformer):
         self.tfm = IVIS(embedding_dims=self.n_components, **self.kwargs)
 
     def fit(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         self.tfm.fit(X)
         self.is_fitted = True
         return self
 
     def transform(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         new_vecs = self.tfm.fit_transform(X)
         names_out = names + [f"ivis_{i}" for i in range(self.n_components)]
         vectors_out = np.concatenate([new_vecs, np.eye(self.n_components)])

--- a/whatlies/transformers/noise.py
+++ b/whatlies/transformers/noise.py
@@ -3,7 +3,7 @@ from sklearn.preprocessing import FunctionTransformer
 
 from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
-from whatlies.transformers.common import embset_to_X, new_embedding_dict
+from whatlies.transformers.common import new_embedding_dict
 
 
 class Noise(Transformer):
@@ -40,13 +40,11 @@ class Noise(Transformer):
         )
 
     def fit(self, embset):
-        names, X = embset_to_X(embset=embset)
-        self.tfm.fit(X)
         self.is_fitted = True
         return self
 
     def transform(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         np.random.seed(self.seed)
         new_vecs = self.tfm.transform(X)
         new_dict = new_embedding_dict(names, new_vecs, embset)

--- a/whatlies/transformers/normalizer.py
+++ b/whatlies/transformers/normalizer.py
@@ -2,7 +2,7 @@ from sklearn.preprocessing import normalize
 
 from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
-from whatlies.transformers.common import embset_to_X, new_embedding_dict
+from whatlies.transformers.common import new_embedding_dict
 
 
 class Normalizer(Transformer):
@@ -43,7 +43,7 @@ class Normalizer(Transformer):
         return self
 
     def transform(self, embset: EmbeddingSet) -> EmbeddingSet:
-        names, X = embset_to_X(embset)
+        names, X = embset.to_names_X()
         axis = 0 if self.feature else 1
         X = normalize(X, norm=self.norm, axis=axis)
         new_dict = new_embedding_dict(names, X, embset)

--- a/whatlies/transformers/opentsne.py
+++ b/whatlies/transformers/opentsne.py
@@ -3,7 +3,7 @@ from openTSNE import TSNE
 
 from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
-from whatlies.transformers.common import embset_to_X, new_embedding_dict
+from whatlies.transformers.common import new_embedding_dict
 
 
 class OpenTsne(Transformer):
@@ -53,13 +53,13 @@ class OpenTsne(Transformer):
         self.tfm = TSNE(n_components=n_components, **kwargs)
 
     def fit(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         self.emb = self.tfm.fit(X)
         self.is_fitted = True
         return self
 
     def transform(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         new_vecs = np.array(self.emb.transform(X))
         names_out = names + [f"tsne_{i}" for i in range(self.n_components)]
         vectors_out = np.concatenate([new_vecs, np.eye(self.n_components)])

--- a/whatlies/transformers/pca.py
+++ b/whatlies/transformers/pca.py
@@ -3,7 +3,7 @@ from sklearn.decomposition import PCA
 
 from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
-from whatlies.transformers.common import embset_to_X, new_embedding_dict
+from whatlies.transformers.common import new_embedding_dict
 
 
 class Pca(Transformer):
@@ -41,13 +41,13 @@ class Pca(Transformer):
         self.tfm = PCA(n_components=n_components)
 
     def fit(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         self.tfm.fit(X)
         self.is_fitted = True
         return self
 
     def transform(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         new_vecs = self.tfm.transform(X)
         names_out = names + [f"pca_{i}" for i in range(self.n_components)]
         vectors_out = np.concatenate([new_vecs, np.eye(self.n_components)])

--- a/whatlies/transformers/tsne.py
+++ b/whatlies/transformers/tsne.py
@@ -3,7 +3,7 @@ from sklearn.manifold import TSNE
 
 from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
-from whatlies.transformers.common import embset_to_X, new_embedding_dict
+from whatlies.transformers.common import new_embedding_dict
 
 
 class Tsne(Transformer):
@@ -45,13 +45,13 @@ class Tsne(Transformer):
         self.tfm = TSNE(n_components=n_components, **kwargs)
 
     def fit(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         self.tfm.fit(X)
         self.is_fitted = True
         return self
 
     def transform(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         new_vecs = self.tfm.fit_transform(X)
         names_out = names + [f"tsne_{i}" for i in range(self.n_components)]
         vectors_out = np.concatenate([new_vecs, np.eye(self.n_components)])

--- a/whatlies/transformers/umap.py
+++ b/whatlies/transformers/umap.py
@@ -6,7 +6,7 @@ from numba import NumbaPerformanceWarning
 
 from whatlies.transformers import Transformer
 from whatlies import EmbeddingSet
-from whatlies.transformers.common import embset_to_X, new_embedding_dict
+from whatlies.transformers.common import new_embedding_dict
 
 
 class Umap(Transformer):
@@ -43,7 +43,7 @@ class Umap(Transformer):
         self.tfm = UMAP(n_components=n_components, **kwargs)
 
     def fit(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             warnings.simplefilter("ignore", category=NumbaPerformanceWarning)
@@ -52,7 +52,7 @@ class Umap(Transformer):
         return self
 
     def transform(self, embset):
-        names, X = embset_to_X(embset=embset)
+        names, X = embset.to_names_X()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=NumbaPerformanceWarning)
             new_vecs = self.tfm.transform(X)


### PR DESCRIPTION
This PR does some refactoring in transformers:

- `embset_to_X` method was removed and instead `to_names_X` method is used.
- Some redundant calls in `fit` method of `Noise` and `AddRandom` were removed.