### PR TITLE
Fix #122 - Add ndim attribute for Embedding and EmbeddingSet

### DIFF
--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -76,3 +76,8 @@ def test_emb_plot_no_err_3d():
 def test_emb_str_method(emb):
     for char in "xyz":
         assert str(emb[char]) == char
+
+
+def test_emb_ndim():
+    foo = Embedding("foo", [0, 1, 0.2])
+    assert foo.ndim == 3

--- a/tests/test_embeddingset.py
+++ b/tests/test_embeddingset.py
@@ -166,3 +166,8 @@ def test_from_names_X():
     names = names[:2]
     with pytest.raises(ValueError, match="The number of given names"):
         EmbeddingSet.from_names_X(names, X)
+
+
+def test_ndim(lang):
+    embset = lang[["red", "blue", "dog"]]
+    assert embset.ndim == 2

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -39,6 +39,13 @@ class Embedding:
         setattr(result, name, func(result))
         return result
 
+    @property
+    def ndim(self):
+        """
+        Return the dimension of embedding vector.
+        """
+        return self.vector.shape[0]
+
     def __add__(self, other) -> "Embedding":
         """
         Add two embeddings together.

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -67,6 +67,13 @@ class EmbeddingSet:
         if len(uniq_shapes) > 1:
             raise ValueError("Not all vectors have the same shape.")
 
+    @property
+    def ndim(self):
+        """
+        Return dimension of embedding vectors in embeddingset.
+        """
+        return next(iter(self.embeddings.values())).ndim
+
     def __contains__(self, item):
         """
         Checks if an item is in the embeddingset.


### PR DESCRIPTION
This PR fixes #122 by adding a `ndim` attribute for `Embedding` class to represent the dimension of embedding vector.

@koaning I did not add this for `EmbeddingSet` since I think you were not in favor of it as discussed in #122. Anyways, the way to implement it would be:

```python
@property
def ndim(self):
    return self.embeddings.values()[0].ndim
```