### PR TITLE
Change default axis value of plot methods

### DIFF
--- a/tests/test_plotting/test_matplotlib/test_embedding_plot.py
+++ b/tests/test_plotting/test_matplotlib/test_embedding_plot.py
@@ -156,9 +156,9 @@ def test_embedding_plot_arrow_emb_axis(embset):
     mpl.pyplot.close(fig)
 
 
-def test_embedding_plot_raises_error_when_no_axis(embset):
+def test_embedding_plot_raises_error_when_incorret_axis_type(embset):
     emb = embset["red"]
-    with pytest.raises(ValueError, match="The `x_axis` value cannot be None"):
-        emb.plot()
-    with pytest.raises(ValueError, match="The `y_axis` value cannot be None"):
-        emb.plot(x_axis=0)
+    with pytest.raises(ValueError, match="The `x_axis` value should be"):
+        emb.plot(x_axis=1.0)
+    with pytest.raises(ValueError, match="The `y_axis` value should be"):
+        emb.plot(y_axis="blue")

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -189,8 +189,8 @@ class Embedding:
     def plot(
         self,
         kind: str = "arrow",
-        x_axis: Union[int, "Embedding"] = None,
-        y_axis: Union[int, "Embedding"] = None,
+        x_axis: Union[int, "Embedding"] = 0,
+        y_axis: Union[int, "Embedding"] = 1,
         x_label: Optional[str] = None,
         y_label: Optional[str] = None,
         title: Optional[str] = None,
@@ -255,17 +255,15 @@ class Embedding:
         as well as the default label of axis.
 
         Arguments:
-            axis: the axis value used for projection. It could be None, an integer or
+            axis: the axis value used for projection. It could be an integer or
                 an `Embedding` instance.
             dir: the axis direction which could be either of `'x'` or `'y'`.
         """
         if isinstance(axis, int):
             return self.vector[axis], "Dimension " + str(axis)
-        if isinstance(axis, Embedding):
+        elif isinstance(axis, Embedding):
             return self > axis, axis.name
-        if axis is None:
-            if len(self.vector) > 2:
-                raise ValueError(
-                    f"The `{dir}_axis` value cannot be None for a {len(self.vector)}D embedding"
-                )
-            return self.vector[0 if dir == "x" else 1], axis
+        else:
+            raise ValueError(
+                f"The `{dir}_axis` value should be an integer or Embedding instance, given: {type(axis)}"
+            )

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -587,8 +587,8 @@ class EmbeddingSet:
     def plot(
         self,
         kind: str = "arrow",
-        x_axis: Union[int, str, Embedding] = None,
-        y_axis: Union[int, str, Embedding] = None,
+        x_axis: Union[int, str, Embedding] = 0,
+        y_axis: Union[int, str, Embedding] = 1,
         x_label: Optional[str] = None,
         y_label: Optional[str] = None,
         title: Optional[str] = None,
@@ -892,8 +892,8 @@ class EmbeddingSet:
 
     def plot_interactive(
         self,
-        x_axis: Union[int, str, Embedding],
-        y_axis: Union[int, str, Embedding],
+        x_axis: Union[int, str, Embedding] = 0,
+        y_axis: Union[int, str, Embedding] = 1,
         x_label: Optional[str] = None,
         y_label: Optional[str] = None,
         title: Optional[str] = None,


### PR DESCRIPTION
This PR changes the default value of `x_axis` and `y_axis` arguments in `plot` and `plot_interactive` methods.

**Backwards incompatible changes:**

- With 2D embeddings, when using `Embedding.plot` or `EmbeddingSet.plot` without setting `x_axis` and `y_axis`, the default axis labels would be "Dimension 0" and "Dimension 1" (instead of "x" and "y").
- With 2D embeddings, when using `Embedding.plot` or `EmbeddingSet.plot`, the `x_axis` and `y_axis` arguments no longer can take `None` value (the previous default value).