### PR TITLE
Fix #129 - Add support for alternative axis metrics in `plot` method

### DIFF
--- a/tests/test_plotting/test_matplotlib/test_embedding_plot.py
+++ b/tests/test_plotting/test_matplotlib/test_embedding_plot.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import matplotlib as mpl
+import scipy.spatial.distance as scipy_distance
 
 from whatlies import Embedding, EmbeddingSet
 from common import validate_plot_general_properties
@@ -156,9 +157,155 @@ def test_embedding_plot_arrow_emb_axis(embset):
     mpl.pyplot.close(fig)
 
 
-def test_embedding_plot_raises_error_when_incorret_axis_type(embset):
+def test_embedding_plot_arrow_integer_axis_with_str_axis_metric(embset):
+    emb = embset["red"]
+    fig, ax = mpl.pyplot.subplots()
+    emb.plot(
+        kind="arrow",
+        x_axis=0,
+        y_axis=2,
+        axis_metric="euclidean",
+        color="blue",
+        x_label="xlabel",
+        y_label="ylabel",
+        title="test plot",
+        annot=False,
+    )
+    props = {
+        "type": mpl.collections.PolyCollection,
+        "data": np.concatenate((emb.vector[0:1], emb.vector[2:3])),
+        "x_label": "xlabel",
+        "y_label": "ylabel",
+        "title": "test plot",
+        "color": mpl.colors.to_rgba_array("blue"),
+        "aspect": "auto",
+        # Not applicable: label
+    }
+    UV = np.concatenate((ax.collections[1].U, ax.collections[1].V))
+    assert isinstance(ax.collections[1], props["type"])
+    assert np.array_equal(UV, props["data"])
+    assert np.array_equal(ax.collections[1].get_facecolor(), props["color"])
+    assert ax.texts == []
+    validate_plot_general_properties(ax, props)
+    mpl.pyplot.close(fig)
+
+
+def test_embedding_plot_scatter_emb_axis_with_common_str_axis_metric(embset):
+    emb = embset["red"]
+    fig, ax = mpl.pyplot.subplots()
+    emb.plot(
+        kind="scatter",
+        x_axis=embset["blue"],
+        y_axis=embset["green"],
+        axis_metric="cosine_distance",
+    )
+    props = {
+        "type": mpl.collections.PathCollection,
+        "data": np.array(
+            [
+                scipy_distance.cosine(emb.vector, embset["blue"].vector),
+                scipy_distance.cosine(emb.vector, embset["green"].vector),
+            ]
+        ),
+        "x_label": "blue",
+        "y_label": "green",
+        "color": mpl.colors.to_rgba_array("steelblue"),
+        "title": "",
+        "label": "red",
+        "aspect": "auto",
+    }
+    assert np.array_equal(ax.collections[0].get_offsets()[0], props["data"])
+    assert isinstance(ax.collections[0], props["type"])
+    assert ax.texts[0].get_text() == props["label"]
+    validate_plot_general_properties(ax, props)
+    mpl.pyplot.close(fig)
+
+
+def test_embedding_plot_arrow_emb_axis_with_different_str_axis_metric(embset):
+    emb = embset["red"] + embset["yellow"]
+    fig, ax = mpl.pyplot.subplots()
+    emb.plot(
+        kind="arrow",
+        x_axis=embset["blue"],
+        y_axis=embset["green"],
+        axis_metric=["euclidean", "cosine_similarity"],
+        color="yellow",
+        show_ops=True,
+        axis_option="equal",
+    )
+    props = {
+        "type": mpl.collections.PolyCollection,
+        "data": np.array(
+            [
+                scipy_distance.euclidean(emb.vector, embset["blue"].vector),
+                1.0 - scipy_distance.cosine(emb.vector, embset["green"].vector),
+            ]
+        ),
+        "x_label": "blue",
+        "y_label": "green",
+        "color": mpl.colors.to_rgba_array("yellow"),
+        "title": "",
+        "label": "(red + yellow)",
+        "aspect": 1.0,
+    }
+    UV = np.concatenate((ax.collections[1].U, ax.collections[1].V))
+    assert isinstance(ax.collections[1], props["type"])
+    assert np.array_equal(UV, props["data"])
+    assert np.array_equal(ax.collections[1].get_facecolor(), props["color"])
+    assert ax.texts[0].get_text() == props["label"]
+    validate_plot_general_properties(ax, props)
+    mpl.pyplot.close(fig)
+
+
+def test_embedding_plot_arrow_emb_axis_with_callable_y_axis_metric(embset):
+    emb = embset["red"] + embset["yellow"]
+    fig, ax = mpl.pyplot.subplots()
+    emb.plot(
+        kind="arrow",
+        x_axis=embset["blue"],
+        y_axis=embset["green"],
+        axis_metric=[None, scipy_distance.correlation],
+        x_label="xaxis",
+        y_label="corr",
+        color="yellow",
+        show_ops=True,
+        axis_option="equal",
+    )
+    props = {
+        "type": mpl.collections.PolyCollection,
+        "data": np.array(
+            [
+                emb > embset["blue"],
+                scipy_distance.correlation(emb.vector, embset["green"].vector),
+            ]
+        ),
+        "x_label": "xaxis",
+        "y_label": "corr",
+        "color": mpl.colors.to_rgba_array("yellow"),
+        "title": "",
+        "label": "(red + yellow)",
+        "aspect": 1.0,
+    }
+    UV = np.concatenate((ax.collections[1].U, ax.collections[1].V))
+    assert isinstance(ax.collections[1], props["type"])
+    assert np.array_equal(UV, props["data"])
+    assert np.array_equal(ax.collections[1].get_facecolor(), props["color"])
+    assert ax.texts[0].get_text() == props["label"]
+    validate_plot_general_properties(ax, props)
+    mpl.pyplot.close(fig)
+
+
+def test_embedding_plot_raises_error_when_incorrect_axis_type(embset):
     emb = embset["red"]
     with pytest.raises(ValueError, match="The `x_axis` value should be"):
         emb.plot(x_axis=1.0)
     with pytest.raises(ValueError, match="The `y_axis` value should be"):
         emb.plot(y_axis="blue")
+
+
+def test_embedding_plot_raises_error_when_incorrect_axis_metric(embset):
+    emb = embset["red"]
+    with pytest.raises(ValueError, match="The given axis metric is not supported"):
+        emb.plot(x_axis=embset["blue"], axis_metric="correlation")
+    with pytest.raises(ValueError, match="The given axis metric type is not"):
+        emb.plot(y_axis=embset["blue"], axis_metric=1)

--- a/tests/test_plotting/test_matplotlib/test_embeddingset_plot.py
+++ b/tests/test_plotting/test_matplotlib/test_embeddingset_plot.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import matplotlib as mpl
+import scipy.spatial.distance as scipy_distance
 
 from whatlies import Embedding, EmbeddingSet
 from common import validate_plot_general_properties
@@ -196,6 +197,115 @@ def test_embeddingset_plot_arrow_emb_axis(embset):
         vec.append(emb > embset["blue"])
         vec.append(emb > embset["red"])
         vectors.append(vec)
+    vectors = np.array(vectors)
+    props = {
+        "type": mpl.collections.PolyCollection,
+        "data": vectors,
+        "x_label": "xx",
+        "y_label": "red",
+        "title": "",
+        "label": list(embset.embeddings.keys()),
+        "color": mpl.colors.to_rgba_array("magenta"),
+        "aspect": "auto",
+    }
+    UV = np.concatenate(
+        (ax.collections[1].U[:, None], ax.collections[1].V[:, None]), axis=-1
+    )
+    assert isinstance(ax.collections[1], props["type"])
+    assert np.array_equal(UV, props["data"])
+    assert [t.get_text() for t in ax.texts] == props["label"]
+    assert np.array_equal(ax.collections[1].get_facecolors(), props["color"])
+    validate_plot_general_properties(ax, props)
+    mpl.pyplot.close(fig)
+
+
+def test_embeddingset_plot_arrow_integer_axis_with_str_axis_metric(embset):
+    fig, ax = mpl.pyplot.subplots()
+    embset.plot(
+        kind="arrow",
+        x_axis=1,
+        y_axis=2,
+        axis_metric="cosine_distance",
+        x_label="1",
+        y_label="2",
+        color="yellow",
+        axis_option="scaled",
+    )
+    vectors = np.concatenate((embset.to_X()[:, 1:2], embset.to_X()[:, 2:3]), axis=-1)
+    props = {
+        "type": mpl.collections.PolyCollection,
+        "data": vectors,
+        "x_label": "1",
+        "y_label": "2",
+        "title": "",
+        "label": list(embset.embeddings.keys()),
+        "color": mpl.colors.to_rgba_array("yellow"),
+        "aspect": 1.0,
+    }
+    UV = np.concatenate(
+        (ax.collections[1].U[:, None], ax.collections[1].V[:, None]), axis=-1
+    )
+    assert isinstance(ax.collections[1], props["type"])
+    assert np.array_equal(UV, props["data"])
+    assert [t.get_text() for t in ax.texts] == props["label"]
+    assert np.array_equal(ax.collections[1].get_facecolors(), props["color"])
+    validate_plot_general_properties(ax, props)
+    mpl.pyplot.close(fig)
+
+
+def test_embeddingset_plot_scatter_emb_axis_with_common_str_axis_metric(embset):
+    fig, ax = mpl.pyplot.subplots()
+    embset.plot(
+        kind="scatter",
+        x_axis=embset["green"],
+        y_axis=embset["white"],
+        axis_metric="euclidean",
+    )
+    vectors = []
+    for emb in embset.embeddings.values():
+        vectors.append(
+            [
+                scipy_distance.euclidean(emb.vector, embset["green"].vector),
+                scipy_distance.euclidean(emb.vector, embset["white"].vector),
+            ]
+        )
+    vectors = np.array(vectors)
+    props = {
+        "type": mpl.collections.PathCollection,
+        "data": vectors,
+        "x_label": "green",
+        "y_label": "white",
+        "title": "",
+        "label": list(embset.embeddings.keys()),
+        "color": mpl.colors.to_rgba_array("steelblue"),
+        "aspect": "auto",
+    }
+    assert isinstance(ax.collections[0], props["type"])
+    assert np.array_equal(ax.collections[0].get_offsets(), props["data"])
+    assert [t.get_text() for t in ax.texts] == props["label"]
+    assert np.array_equal(ax.collections[0].get_facecolors(), props["color"])
+    validate_plot_general_properties(ax, props)
+    mpl.pyplot.close(fig)
+
+
+def test_embeddingset_plot_arrow_emb_axis_with_different_axis_metric(embset):
+    fig, ax = mpl.pyplot.subplots()
+    embset.plot(
+        kind="arrow",
+        x_axis=embset["blue"],
+        y_axis="red",
+        axis_metric=[scipy_distance.correlation, "cosine_similarity"],
+        x_label="xx",
+        color="magenta",
+    )
+    vectors = []
+    for emb in embset.embeddings.values():
+        vectors.append(
+            [
+                scipy_distance.correlation(emb.vector, embset["blue"].vector),
+                1.0 - scipy_distance.cosine(emb.vector, embset["red"].vector),
+            ]
+        )
     vectors = np.array(vectors)
     props = {
         "type": mpl.collections.PolyCollection,


### PR DESCRIPTION
This PR partially addresses #129 by adding support for custom axis metrics in matplotlib plots (i.e. `plot` method).

---
**TODO**:

- [X] Implement support for custom axis metric in `Embedding.plot` method.
- [X] Add tests for custom axis metric of `Embedding.plot` method.
- [X] Implement support for custom axis metric in `EmbeddingSet.plot` method.
- [X] Add tests for custom axis metric of `EmbeddingSet.plot` method.

---
**Backwards incompatible changes:** None.