### PR TITLE
Fix #129 - Add support for alternative axis metrics in Altair plot methods

### DIFF
--- a/tests/test_embeddingset.py
+++ b/tests/test_embeddingset.py
@@ -171,3 +171,33 @@ def test_from_names_X():
 def test_ndim(lang):
     embset = lang[["red", "blue", "dog"]]
     assert embset.ndim == 2
+
+
+def test_compare_against(lang):
+    embset = lang[["red", "blue", "cat"]]
+    compared = embset.compare_against(lang["green"])
+    true_values = np.array(
+        [
+            embset["red"] > lang["green"],
+            embset["blue"] > lang["green"],
+            embset["cat"] > lang["green"],
+        ]
+    )
+    assert np.array_equal(compared, true_values)
+
+    # Test with custom mapping function
+    compared = embset.compare_against("cat", mapping=np.dot)
+    true_values = np.array(
+        [
+            np.dot(embset["red"].vector, lang["cat"].vector),
+            np.dot(embset["blue"].vector, lang["cat"].vector),
+            np.dot(embset["cat"].vector, lang["cat"].vector),
+        ]
+    )
+    assert np.array_equal(compared, true_values)
+
+    # Test with non-existent name or invalid mapping
+    with pytest.raises(KeyError):
+        embset.compare_against("purple")
+    with pytest.raises(ValueError, match="Unrecognized mapping value/type."):
+        embset.compare_against(lang["green"], mapping="cosine")

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -203,9 +203,12 @@ class EmbeddingSet:
         new_embeddings = {k: emb >> other for k, emb in self.embeddings.items()}
         return EmbeddingSet(new_embeddings, name=f"({self.name} >> {other.name})")
 
-    def compare_against(self, other, mapping="direct"):
+    def compare_against(self, other, mapping="direct", func=None):
         if mapping == "direct":
-            return [v > other for k, v in self.embeddings.items()]
+            if func is None:
+                return [v > other for v in self.embeddings.values()]
+            else:
+                return [func(v.vector, other.vector) for v in self.embeddings.values()]
 
     def pipe(self, func, *args, **kwargs):
         """
@@ -912,6 +915,7 @@ class EmbeddingSet:
         self,
         x_axis: Union[int, str, Embedding] = 0,
         y_axis: Union[int, str, Embedding] = 1,
+        axis_metric: Optional[Union[str, Callable, Sequence]] = None,
         x_label: Optional[str] = None,
         y_label: Optional[str] = None,
         title: Optional[str] = None,
@@ -927,6 +931,11 @@ class EmbeddingSet:
                 dimension of embedding is used.
             y_axis: the y-axis to be used, must be given when dim > 2; if an integer, the corresponding
                 dimension of embedding is used.
+            axis_metric: the metric used to project each embedding on the axes; only used when the corresponding
+                axis (i.e. `x_axis` or `y_axis`) is a string or an `Embedding` instance. It could be a string
+                (`'cosine_similarity'`, `'cosine_distance'` or `'euclidean'`), or a callable that takes two vectors as input
+                and returns a scalar value as output. To set different metrics for x- and y-axis, a list or a tuple of
+                two elements could be given. By default (`None`), normalized scalar projection (i.e. `>` operator) is used.
             x_label: an optional label used for x-axis; if not given, it is set based on `x_axis` value.
             y_label: an optional label used for y-axis; if not given, it is set based on `y_axis` value.
             title: an optional title for the plot; if not given, it is set based on `x_axis` and `y_axis` values.
@@ -955,19 +964,28 @@ class EmbeddingSet:
         if isinstance(y_axis, str):
             y_axis = self[y_axis]
 
+        if isinstance(axis_metric, (list, tuple)):
+            x_axis_metric = axis_metric[0]
+            y_axis_metric = axis_metric[1]
+        else:
+            x_axis_metric = axis_metric
+            y_axis_metric = axis_metric
+
         # Determine axes values and labels
         if isinstance(x_axis, int):
             x_val = self.to_X()[:, x_axis]
             x_lab = "Dimension " + str(x_axis)
         else:
-            x_val = self.compare_against(x_axis)
+            x_axis_metric = Embedding._get_plot_axis_metric_callable(x_axis_metric)
+            x_val = self.compare_against(x_axis, func=x_axis_metric)
             x_lab = x_axis.name
 
         if isinstance(y_axis, int):
             y_val = self.to_X()[:, y_axis]
             y_lab = "Dimension " + str(y_axis)
         else:
-            y_val = self.compare_against(y_axis)
+            y_axis_metric = Embedding._get_plot_axis_metric_callable(y_axis_metric)
+            y_val = self.compare_against(y_axis, func=y_axis_metric)
             y_lab = y_axis.name
         x_label = x_label if x_label is not None else x_lab
         y_label = y_label if y_label is not None else y_lab
@@ -1020,6 +1038,7 @@ class EmbeddingSet:
     def plot_interactive_matrix(
         self,
         *axes: Union[int, str, Embedding],
+        axes_metric: Optional[Union[str, Callable, Sequence]] = None,
         annot: bool = True,
         show_axis_point: bool = False,
         width: int = 200,
@@ -1031,6 +1050,11 @@ class EmbeddingSet:
         Arguments:
             axes: the axes that we wish to plot; each could be either an integer, the name of
                 an existing embedding, or an `Embedding` instance (default: `0, 1`).
+            axes_metric: the metric used to project each embedding on the axes; only used when the corresponding
+                axis is a string or an `Embedding` instance. It could be a string (`'cosine_similarity'`,
+                `'cosine_distance'` or `'euclidean'`), or a callable that takes two vectors as input and
+                returns a scalar value as output. To set different metrics for different axes, a list or a tuple of
+                the same length as `axes` could be given. By default (`None`), normalized scalar projection (i.e. `>` operator) is used.
             annot: drawn points should be annotated
             show_axis_point: ensure that the axis are drawn
             width: width of the visual
@@ -1057,17 +1081,25 @@ class EmbeddingSet:
         if len(axes) == 0:
             axes = [0, 1]
 
+        if isinstance(axes_metric, (list, tuple)) and len(axes_metric) != len(axes):
+            raise ValueError(
+                f"The number of given axes metrics should be the same as the number of given axes. Got {len(axes)} axes vs. {len(axes_metric)} metrics."
+            )
+        if not isinstance(axes_metric, (list, tuple)):
+            axes_metric = [axes_metric] * len(axes)
+
         # Get values of each axis according to their type.
         axes_vals = {}
         X = self.to_X()
-        for axis in axes:
+        for axis, metric in zip(axes, axes_metric):
             if isinstance(axis, int):
                 vals = X[:, axis]
                 axes_vals["Dimension " + str(axis)] = vals
             else:
                 if isinstance(axis, str):
                     axis = self[axis]
-                vals = self.compare_against(axis)
+                metric = Embedding._get_plot_axis_metric_callable(metric)
+                vals = self.compare_against(axis, func=metric)
                 axes_vals[axis.name] = vals
 
         plot_df = pd.DataFrame(axes_vals)


### PR DESCRIPTION
This PR partially addresses #129 by adding support for custom axis metric in Altair plot methods. To make the implementation easier, we added a new optional argument for `EmbeddingSet.compare_against` method to take custom functions.

**Update**: The `EmbeddingSet.compare_against` were refactored to use the already present argument for handling custom functions as well.

---
**TODO**:

- [X] Add support for axis metric in `EmbeddingSet.plot_interactive` method.
- [X] Add support for axis metric in `EmbeddingSet.plot_interactive_matrix` method.
- [X] Add tests for `EmbeddingSet.compare_against` method.
- [X] Run manual local tests.

---
**Backwards incompatible changes:** None.