### PR TITLE
Adding 3D-Plot #200

### DIFF
--- a/tests/test_plotting/test_matplotlib/test_plot_3d.py
+++ b/tests/test_plotting/test_matplotlib/test_plot_3d.py
@@ -1,0 +1,57 @@
+import pytest
+
+from whatlies.language import SpacyLanguage
+from whatlies.transformers import Pca
+
+
+words = [
+    "prince",
+    "princess",
+    "nurse",
+    "doctor",
+    "banker",
+    "man",
+    "woman",
+    "cousin",
+    "neice",
+    "king",
+    "queen",
+    "dude",
+    "guy",
+    "gal",
+    "fire",
+    "dog",
+    "cat",
+    "mouse",
+    "red",
+    "bluee",
+    "green",
+    "yellow",
+    "water",
+    "person",
+    "family",
+    "brother",
+    "sister",
+]
+
+
+@pytest.fixture
+def embset():
+    lang = SpacyLanguage("en_core_web_md")
+    return lang[words]
+
+
+def test_basic_dimensions_3d_chart(embset):
+    ax = embset.transform(Pca(3)).plot_3d(annot=True)
+    assert ax.xaxis.get_label_text() == "Dimension 0"
+    assert ax.yaxis.get_label_text() == "Dimension 1"
+    assert ax.zaxis.get_label_text() == "Dimension 2"
+    assert [t.get_text() for t in ax.texts] == words
+
+
+def test_named_dimensions_3d_chart(embset):
+    ax = embset.transform(Pca(3)).plot_3d("king", "queen", "prince", annot=True)
+    assert ax.xaxis.get_label_text() == "king"
+    assert ax.yaxis.get_label_text() == "queen"
+    assert ax.zaxis.get_label_text() == "prince"
+    assert [t.get_text() for t in ax.texts] == words

--- a/tests/test_plotting/test_matplotlib/test_plot_3d.py
+++ b/tests/test_plotting/test_matplotlib/test_plot_3d.py
@@ -45,6 +45,11 @@ def embset():
     return lang[words]
 
 
+def test_set_title_works(embset):
+    ax = embset.plot_3d(annot=True, title="foobar")
+    assert ax.title._text == "foobar"
+
+
 def test_correct_points_plotted(embset):
     embset_plt = embset.transform(Pca(3))
     ax = embset_plt.plot_3d(annot=True)
@@ -65,7 +70,7 @@ def test_correct_points_plotted_mapped(embset):
 
 def test_basic_dimensions_3d_chart(embset):
     embset_plt = embset.transform(Pca(3))
-    ax = embset_plt.plot_3d(annot=True)
+    ax = embset_plt.plot_3d(annot=True, title="foobar")
     assert ax.xaxis.get_label_text() == "Dimension 0"
     assert ax.yaxis.get_label_text() == "Dimension 1"
     assert ax.zaxis.get_label_text() == "Dimension 2"
@@ -76,5 +81,15 @@ def test_named_dimensions_3d_chart(embset):
     ax = embset.transform(Pca(3)).plot_3d("king", "queen", "prince", annot=True)
     assert ax.xaxis.get_label_text() == "king"
     assert ax.yaxis.get_label_text() == "queen"
+    assert ax.zaxis.get_label_text() == "prince"
+    assert [t.get_text() for t in ax.texts] == words
+
+
+def test_named_dimensions_3d_chart_rename(embset):
+    ax = embset.transform(Pca(3)).plot_3d(
+        "king", "queen", "prince", annot=True, x_label="x", y_label="y"
+    )
+    assert ax.xaxis.get_label_text() == "x"
+    assert ax.yaxis.get_label_text() == "y"
     assert ax.zaxis.get_label_text() == "prince"
     assert [t.get_text() for t in ax.texts] == words

--- a/tests/test_plotting/test_matplotlib/test_plot_3d.py
+++ b/tests/test_plotting/test_matplotlib/test_plot_3d.py
@@ -1,5 +1,7 @@
 import pytest
 
+import numpy as np
+
 from whatlies.language import SpacyLanguage
 from whatlies.transformers import Pca
 
@@ -34,15 +36,36 @@ words = [
     "sister",
 ]
 
+# I'm loading in the spaCy model globally because it is much faster this way.
+lang = SpacyLanguage("en_core_web_md")
+
 
 @pytest.fixture
 def embset():
-    lang = SpacyLanguage("en_core_web_md")
     return lang[words]
 
 
+def test_correct_points_plotted(embset):
+    embset_plt = embset.transform(Pca(3))
+    ax = embset_plt.plot_3d(annot=True)
+    offset = ax.collections[0]._offsets3d
+    assert np.all(np.array(offset).T == embset_plt.to_X())
+
+
+def test_correct_points_plotted_mapped(embset):
+    embset_plt = embset.transform(Pca(3))
+    ax = embset_plt.plot_3d("king", "red", "dog", annot=True)
+    offset = ax.collections[0]._offsets3d
+    king, red, dog = [v for v in np.array(offset)]
+
+    assert np.all(king == np.array([embset_plt[w] > embset_plt["king"] for w in words]))
+    assert np.all(red == np.array([embset_plt[w] > embset_plt["red"] for w in words]))
+    assert np.all(dog == np.array([embset_plt[w] > embset_plt["dog"] for w in words]))
+
+
 def test_basic_dimensions_3d_chart(embset):
-    ax = embset.transform(Pca(3)).plot_3d(annot=True)
+    embset_plt = embset.transform(Pca(3))
+    ax = embset_plt.plot_3d(annot=True)
     assert ax.xaxis.get_label_text() == "Dimension 0"
     assert ax.yaxis.get_label_text() == "Dimension 1"
     assert ax.zaxis.get_label_text() == "Dimension 2"

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -301,7 +301,7 @@ class Embedding:
         elif isinstance(axis_metric, str):
             if axis_metric == "cosine":
                 raise ValueError(
-                    "Please be specific, do you want `cosine_distance` or `cosine_similarity`."
+                    "Please be specific, do you want `cosine_distance` or `cosine_similarity`?"
                 )
             elif axis_metric == "cosine_similarity":
                 return lambda x, y: 1.0 - scipy_distance.cosine(x, y)

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -299,7 +299,11 @@ class Embedding:
         if axis_metric is None:
             return None
         elif isinstance(axis_metric, str):
-            if axis_metric == "cosine_similarity":
+            if axis_metric == "cosine":
+                raise ValueError(
+                    "Please be specific, do you want `cosine_distance` or `cosine_similarity`."
+                )
+            elif axis_metric == "cosine_similarity":
                 return lambda x, y: 1.0 - scipy_distance.cosine(x, y)
             elif axis_metric == "cosine_distance":
                 return scipy_distance.cosine

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -684,8 +684,12 @@ class EmbeddingSet:
         x_axis: Union[int, str, Embedding] = 0,
         y_axis: Union[int, str, Embedding] = 1,
         z_axis: Union[int, str, Embedding] = 2,
+        x_label: Optional[str] = None,
+        y_label: Optional[str] = None,
+        z_label: Optional[str] = None,
+        title: Optional[str] = None,
         color: str = None,
-        axes_metric: Optional[Union[str, Callable, Sequence]] = None,
+        axis_metric: Optional[Union[str, Callable, Sequence]] = None,
         annot: bool = True,
     ):
         """
@@ -698,12 +702,17 @@ class EmbeddingSet:
                 dimension of embedding is used.
             z_axis: the z-axis to be used, must be given when dim > 3; if an integer, the corresponding
                 dimension of embedding is used.
+            x_label: an optional label used for x-axis; if not given, it is set based on value of `x_axis`.
+            y_label: an optional label used for y-axis; if not given, it is set based on value of `y_axis`.
+            z_label: an optional label used for z-axis; if not given, it is set based on value of `z_axis`.
+            title: an optional title for the plot.
             color: the property to user for the color
-            axes_metric: the metric used to project each embedding on the axes; only used when the corresponding
+            axis_metric: the metric used to project each embedding on the axes; only used when the corresponding
                 axis is a string or an `Embedding` instance. It could be a string (`'cosine_similarity'`,
                 `'cosine_distance'` or `'euclidean'`), or a callable that takes two vectors as input and
-                returns a scalar value as output. To set different metrics for different axes, a list or a tuple of
-                the same length as `axes` could be given. By default (`None`), normalized scalar projection (i.e. `>` operator) is used.
+                returns a scalar value as output. To set different metrics of the three different axes,
+                a list or a tuple of the same length as `axes` could be given. By default (`None`),
+                normalized scalar projection (i.e. `>` operator) is used.
             annot: drawn points should be annotated
 
         **Usage**
@@ -730,14 +739,14 @@ class EmbeddingSet:
         if isinstance(z_axis, str):
             z_axis = self[z_axis]
 
-        if isinstance(axes_metric, (list, tuple)):
-            x_axis_metric = axes_metric[0]
-            y_axis_metric = axes_metric[1]
-            z_axis_metric = axes_metric[2]
+        if isinstance(axis_metric, (list, tuple)):
+            x_axis_metric = axis_metric[0]
+            y_axis_metric = axis_metric[1]
+            z_axis_metric = axis_metric[2]
         else:
-            x_axis_metric = axes_metric
-            y_axis_metric = axes_metric
-            z_axis_metric = axes_metric
+            x_axis_metric = axis_metric
+            y_axis_metric = axis_metric
+            z_axis_metric = axis_metric
 
         # Determine axes values and labels
         if isinstance(x_axis, int):
@@ -746,7 +755,7 @@ class EmbeddingSet:
         else:
             x_axis_metric = Embedding._get_plot_axis_metric_callable(x_axis_metric)
             x_val = self.compare_against(x_axis, mapping=x_axis_metric)
-            x_lab = x_axis.name
+            x_lab = x_label if x_label else x_axis.name
 
         if isinstance(y_axis, int):
             y_val = self.to_X()[:, y_axis]
@@ -754,7 +763,7 @@ class EmbeddingSet:
         else:
             y_axis_metric = Embedding._get_plot_axis_metric_callable(y_axis_metric)
             y_val = self.compare_against(y_axis, mapping=y_axis_metric)
-            y_lab = y_axis.name
+            y_lab = y_label if y_label else y_axis.name
 
         if isinstance(z_axis, int):
             z_val = self.to_X()[:, z_axis]
@@ -762,7 +771,7 @@ class EmbeddingSet:
         else:
             z_axis_metric = Embedding._get_plot_axis_metric_callable(z_axis_metric)
             z_val = self.compare_against(z_axis, mapping=z_axis_metric)
-            z_lab = z_axis.name
+            z_lab = z_label if z_label else z_axis.name
 
         plot_df = pd.DataFrame(
             {
@@ -788,8 +797,10 @@ class EmbeddingSet:
         if annot:
             for i, row in plot_df.iterrows():
                 ax.text(
-                    row["x_axis"], row["y_axis"], row["z_axis"] + 0.2, row["original"]
+                    row["x_axis"], row["y_axis"], row["z_axis"] + 0.05, row["original"]
                 )
+        if title:
+            ax.set_title(title=title)
         return ax
 
     def plot_graph_layout(self, kind="cosine", **kwargs):


### PR DESCRIPTION
This adresses https://github.com/RasaHQ/whatlies/issues/200. 

```python
emb.transform(Pca(3)).plot_3d(annot=True)
```

![image](https://user-images.githubusercontent.com/1019791/92602254-34114600-f2ae-11ea-8028-4ba920e96dde.png)

```python
emb.transform(Pca(3)).plot_3d("king", "dude", "green", annot=True)
```

![image](https://user-images.githubusercontent.com/1019791/92602270-383d6380-f2ae-11ea-8eff-703d3cd4904b.png)

There's a few things about this PR worth discussing. 

1. The color property works differently in 3d charts. It seems as if the color is automatically altered depending on the depth of the point. Since this is a sensible way of dealing with it I'm wondering if this is something we want to influence directly. 
2. I'm currently adding an absolute value to offset the text from the 3d point. It kind of works but it depends on the zoom level. @mkaze might this be better as an argument? 
3. It feels like we might be able to generalise the plots. They always have a phase where a DataFrame is created for the plot and it seems like a lot of code is repeating itself. This is not something I want to adress in this PR but it is something I've observed. 
4. Testing 3D plots is different. When you call `ax.collections[0].get_offsets()` then you seem to get the 2d coordinates of the points that are plotted instead of the original 3d ones. I've added some basic tests for now, but I'll gladly hear it if we need more. I'm still investigating how the 3d properties work exactly in matplotlib. 
