### PR TITLE
Add .assign verb #155

### DIFF
--- a/tests/test_embeddingset.py
+++ b/tests/test_embeddingset.py
@@ -201,3 +201,22 @@ def test_compare_against(lang):
         embset.compare_against("purple")
     with pytest.raises(ValueError, match="Unrecognized mapping value/type."):
         embset.compare_against(lang["green"], mapping="cosine")
+
+
+def test_add_property():
+    foo = Embedding("foo", [0.1, 0.3, 0.10])
+    bar = Embedding("bar", [0.7, 0.2, 0.11])
+    emb = EmbeddingSet(foo, bar)
+    emb_with_property = emb.add_property("prop_a", lambda d: "prop-one")
+    assert all([e.prop_a == "prop-one" for e in emb_with_property])
+
+
+def test_assign():
+    foo = Embedding("foo", [0.1, 0.3, 0.10])
+    bar = Embedding("bar", [0.7, 0.2, 0.11])
+    emb = EmbeddingSet(foo, bar)
+    emb_with_property = emb.assign(
+        prop_a=lambda d: "prop-one", prop_b=lambda d: "prop-two"
+    )
+    assert all([e.prop_a == "prop-one" for e in emb_with_property])
+    assert all([e.prop_b == "prop-two" for e in emb_with_property])

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -36,11 +36,7 @@ class Embedding:
         self.vector = np.array(vector)
 
     def add_property(self, name, func):
-        result = Embedding(
-            name=self.name,
-            vector=self.vector,
-            orig=self.orig,
-        )
+        result = self.copy()
         setattr(result, name, func(result))
         return result
 
@@ -50,6 +46,12 @@ class Embedding:
         Return the dimension of embedding vector.
         """
         return self.vector.shape[0]
+
+    def copy(self):
+        """
+        Returns a deepcopy of the embdding.
+        """
+        return deepcopy(self)
 
     def __add__(self, other) -> "Embedding":
         """

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -446,6 +446,38 @@ class EmbeddingSet:
         """
         return EmbeddingSet({**self.embeddings, **other.embeddings})
 
+    def assign(self, **kwargs):
+        """
+        Adds properties to every embedding in the set based on the keyword arguments.
+
+        This is very useful for plotting because a property can be used to assign colors. This method is very
+        similar to `.add_property` but it might be more convenient when you want to assign multiple properties
+        in one single statement.
+
+        Arguments:
+            kwargs: (name, func)-pairs that describe the name of the property as well as a function on how to calculate it
+
+        Usage:
+
+        ```python
+        from whatlies.embeddingset import EmbeddingSet
+
+        foo = Embedding("foo", [0.1, 0.3, 0.10])
+        bar = Embedding("bar", [0.7, 0.2, 0.11])
+        emb = EmbeddingSet(foo, bar)
+        emb_with_property = emb.assign(dim0=lambda d: d.vector[0],
+                                       dim1=lambda d: d.vector[1],
+                                       dim2=lambda d: d.vector[2])
+        ```
+        """
+        new_set = {}
+        for k, e in self.embeddings.items():
+            new_emb = e.copy()
+            for name, func in kwargs.items():
+                new_emb = new_emb.add_property(name, func)
+            new_set[k] = new_emb
+        return EmbeddingSet(new_set)
+
     def add_property(self, name, func):
         """
         Adds a property to every embedding in the set. Very useful for plotting because

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -456,6 +456,7 @@ class EmbeddingSet:
 
         Arguments:
             kwargs: (name, func)-pairs that describe the name of the property as well as a function on how to calculate it
+            The function expects an `Embedding` object as input.
 
         Usage:
 
@@ -472,7 +473,7 @@ class EmbeddingSet:
         """
         new_set = {}
         for k, e in self.embeddings.items():
-            new_emb = e.copy()
+            new_emb = e
             for name, func in kwargs.items():
                 new_emb = new_emb.add_property(name, func)
             new_set[k] = new_emb


### PR DESCRIPTION
This PR fixes https://github.com/RasaHQ/whatlies/issues/155. I've left the `add_property` intract since it's not hurting anyone but I have changed the internals of `embedding` slighty. I added a `copy()` command such that we have a convenient method to get a copy of the embedding that also has all of the properties attached. 

The api currently works swell but this PR is making me wonder if in the future, we may want to not have properties added to the `Embedding` interactively since it might be more used friendly to add all of these custom properties in a `data` field on the `Embedding`. Technically, currently a user can `embset.assign(vector=lambda d: 1)` and it'd be no bueno. 

@mkaze got thoughts on this? I'll gladly make an issue for this if you feel the same way. 