### PR TITLE
Remove redundant text property in `plot_interactive_matrix`

### DIFF
--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -1264,7 +1264,6 @@ class EmbeddingSet:
                 x=alt.X(alt.repeat("column"), type="quantitative"),
                 y=alt.Y(alt.repeat("row"), type="quantitative"),
                 tooltip=["name", "original"],
-                text="original",
             )
         )
         if annot:


### PR DESCRIPTION
This PR removes the redundant `text` property used in `plot_interactive_matrix`.