### PR TITLE
Fix a minor error in `assign` method docstring

### DIFF
--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -457,8 +457,8 @@ class EmbeddingSet:
         in one single statement.
 
         Arguments:
-            kwargs: (name, func)-pairs that describe the name of the property as well as a function on how to calculate it
-            The function expects an `Embedding` object as input.
+            kwargs: (name, func)-pairs that describe the name of the property as well as a function on how to calculate it.
+                The function expects an `Embedding` object as input.
 
         Usage:
 


### PR DESCRIPTION
The missing indentation caused the second sentence to not be shown in the method [documentation](https://rasahq.github.io/whatlies/api/embeddingset/#whatlies.embeddingset.EmbeddingSet.assign).