### PR TITLE
Fix #207 - Add Warnings for Axis Metrics

### DIFF
--- a/tests/test_plotting/test_matplotlib/common.py
+++ b/tests/test_plotting/test_matplotlib/common.py
@@ -2,4 +2,5 @@ def validate_plot_general_properties(ax, props):
     assert ax.xaxis.get_label_text() == props["x_label"]
     assert ax.yaxis.get_label_text() == props["y_label"]
     assert ax.get_title() == props["title"]
+    print(ax.get_aspect())
     assert ax.get_aspect() == props["aspect"]

--- a/tests/test_plotting/test_matplotlib/common.py
+++ b/tests/test_plotting/test_matplotlib/common.py
@@ -2,5 +2,4 @@ def validate_plot_general_properties(ax, props):
     assert ax.xaxis.get_label_text() == props["x_label"]
     assert ax.yaxis.get_label_text() == props["y_label"]
     assert ax.get_title() == props["title"]
-    print(ax.get_aspect())
     assert ax.get_aspect() == props["aspect"]

--- a/tests/test_plotting/test_matplotlib/test_embedding_plot.py
+++ b/tests/test_plotting/test_matplotlib/test_embedding_plot.py
@@ -309,3 +309,9 @@ def test_embedding_plot_raises_error_when_incorrect_axis_metric(embset):
         emb.plot(x_axis=embset["blue"], axis_metric="correlation")
     with pytest.raises(ValueError, match="The given axis metric type is not"):
         emb.plot(y_axis=embset["blue"], axis_metric=1)
+
+
+def test_embeddingset_plot3d_raises_warning_axis_metric_no_emb(embset):
+    emb = embset["red"]
+    with pytest.warns(UserWarning):
+        emb.plot(axis_metric="cosine_distance")

--- a/tests/test_plotting/test_matplotlib/test_embeddingset_plot.py
+++ b/tests/test_plotting/test_matplotlib/test_embeddingset_plot.py
@@ -392,3 +392,18 @@ def test_embeddingset_plot_raises_error_when_str_axis_not_exists(embset):
         embset.plot(x_axis="bnb", y_axis="blue")
     with pytest.raises(KeyError):
         embset.plot(x_axis="red", y_axis="clk")
+
+
+def test_embeddingset_plot_raises_warning_axis_metric_no_emb(embset):
+    with pytest.warns(UserWarning):
+        embset.plot(axis_metric="cosine_distance")
+
+
+def test_embeddingset_plot3d_raises_warning_axis_metric_no_emb(embset):
+    with pytest.warns(UserWarning):
+        embset.plot_3d(axis_metric="cosine_distance")
+
+
+def test_embeddingset_plo_interactive_raises_warning_axis_metric_no_emb(embset):
+    with pytest.warns(UserWarning):
+        embset.plot_interactive(axis_metric="cosine_distance")

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -1,5 +1,6 @@
 from typing import Union, Optional, Sequence, Callable
 from copy import deepcopy
+import warnings
 
 import numpy as np
 import scipy.spatial.distance as scipy_distance
@@ -240,6 +241,13 @@ class Embedding:
         bar.plot(kind="arrow", annot=True)
         ```
         """
+        if isinstance(x_axis, int) and isinstance(y_axis, int):
+            if axis_metric is not None:
+                warnings.warn(
+                    f"Ignoring axis_metric={axis_metric} because x_axis/y_axis don't refer to an embedding.",
+                    UserWarning,
+                )
+
         if isinstance(axis_metric, (list, tuple)):
             x_axis_metric = axis_metric[0]
             y_axis_metric = axis_metric[1]

--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from functools import reduce
 from collections import Counter
 from typing import Union, Optional, Callable, Sequence, List
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -677,6 +678,13 @@ class EmbeddingSet:
                 [documentation](https://matplotlib.org/3.1.0/api/_as_gen/matplotlib.pyplot.axis.html#matplotlib-pyplot-axis)
                 for possible values and their description.
         """
+        if isinstance(x_axis, int) and isinstance(y_axis, int):
+            if axis_metric is not None:
+                warnings.warn(
+                    f"Ignoring axis_metric={axis_metric} because x_axis/y_axis don't refer to an embedding.",
+                    UserWarning,
+                )
+
         if isinstance(x_axis, str):
             x_axis = self[x_axis]
         if isinstance(y_axis, str):
@@ -769,6 +777,17 @@ class EmbeddingSet:
         emb.transform(Pca(3)).plot_3d("king", "dog", "red", axis_metric="cosine_distance")
         ```
         """
+        if (
+            isinstance(x_axis, int)
+            and isinstance(y_axis, int)
+            and isinstance(z_axis, int)
+        ):
+            if axis_metric is not None:
+                warnings.warn(
+                    f"Ignoring axis_metric={axis_metric} because x_axis/y_axis/z_axis don't refer to an embedding.",
+                    UserWarning,
+                )
+
         if isinstance(x_axis, str):
             x_axis = self[x_axis]
         if isinstance(y_axis, str):
@@ -1147,6 +1166,13 @@ class EmbeddingSet:
         emb.plot_interactive('man', 'woman')
         ```
         """
+        if isinstance(x_axis, int) and isinstance(y_axis, int):
+            if axis_metric is not None:
+                warnings.warn(
+                    f"Ignoring axis_metric={axis_metric} because x_axis/y_axis don't refer to an embedding.",
+                    UserWarning,
+                )
+
         if isinstance(x_axis, str):
             x_axis = self[x_axis]
         if isinstance(y_axis, str):


### PR DESCRIPTION
This PR fixes https://github.com/RasaHQ/whatlies/issues/207. 

I've added warnings to `EmbeddingSet.plot`, `EmbeddingSet.plot_3d`, `EmbeddingSet.plot_interactive` and `Embedding.plot`. When a user picks a `axis_metric` without specifying an embedding in a plot call they'll now get a warning that it is ignored. 

I've also added tests for all these. 