### PR TITLE
Minor Feature: Add Negation Operator to Embedding

### DIFF
--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -85,4 +85,4 @@ def test_emb_ndim():
 
 def test_negation():
     foo = Embedding("foo", [0.1, 0.3])
-    assert np.all(np.isclose((-foo).vector, -np.array([0.1, 0.3])))
+    assert np.allclose((-foo).vector, -np.array([0.1, 0.3]))

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -81,3 +81,8 @@ def test_emb_str_method(emb):
 def test_emb_ndim():
     foo = Embedding("foo", [0, 1, 0.2])
     assert foo.ndim == 3
+
+
+def test_negation():
+    foo = Embedding("foo", [0.1, 0.3])
+    assert np.all(np.isclose((-foo).vector, -np.array([0.1, 0.3])))

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -93,6 +93,25 @@ class Embedding:
         copied.vector = self.vector - other.vector
         return copied
 
+    def __neg__(self):
+        """
+        Negate a embedding.
+
+        Usage:
+
+        ```python
+        from whatlies.embedding import Embedding
+
+        foo = Embedding("foo", [0.1, 0.3])
+
+        assert (- foo).vector == - foo.vector
+        ```
+        """
+        copied = deepcopy(self)
+        copied.name = f"(- {self.name})"
+        copied.vector = -self.vector
+        return copied
+
     def __gt__(self, other):
         """
         Measures the size of one embedding to another one.

--- a/whatlies/embedding.py
+++ b/whatlies/embedding.py
@@ -95,7 +95,7 @@ class Embedding:
 
     def __neg__(self):
         """
-        Negate a embedding.
+        Negate an embedding.
 
         Usage:
 
@@ -108,7 +108,7 @@ class Embedding:
         ```
         """
         copied = deepcopy(self)
-        copied.name = f"(- {self.name})"
+        copied.name = f"(-{self.name})"
         copied.vector = -self.vector
         return copied
 


### PR DESCRIPTION
I wanted to do:

```python
lang.score_similar(-lang['blue'])
```

But this caused an error. I figured adding `__neg__` is helpful. Allows for more "playfullness". 