### PR TITLE
Update NotInstalled

### DIFF
--- a/whatlies/error.py
+++ b/whatlies/error.py
@@ -10,8 +10,13 @@ class NotInstalled:
         self.tool = tool
         self.dep = dep
 
-    def __call__(self, *args, **kwargs):
         msg = f"In order to use {self.tool} you'll need to install via;\n\n"
         msg += f"pip install whatlies[{self.dep}]\n\n"
         msg += "See installation guide here: https://rasahq.github.io/whatlies/#installation."
-        raise ModuleNotFoundError(msg)
+        self.msg = msg
+
+    def __getattr__(self, *args, **kwargs):
+        raise ModuleNotFoundError(self.msg)
+
+    def __call__(self, *args, **kwargs):
+        raise ModuleNotFoundError(self.msg)


### PR DESCRIPTION
To accommodate a wider range of objects that can be replaced.

```python
try:
    import pandas as pd
except ModuleNotFoundError as e:
    dcc = NotInstalled("pandas", "<reference to conditional import set>")
     
pd.DataFrame() # Will raise friendly error with instructions how to solve
```

p.s. Really nice pattern! I used it in a project after learning about it here https://koaning.io/posts/cool-commits/