### PR TITLE
Update ConveRT models' URLs

### DIFF
--- a/whatlies/language/_convert_lang.py
+++ b/whatlies/language/_convert_lang.py
@@ -48,9 +48,9 @@ class ConveRTLanguage(SklearnTransformerMixin):
     """
 
     MODEL_URL = {
-        "convert": "http://models.poly-ai.com/convert/v1/model.tar.gz",
-        "convert-multi-context": "http://models.poly-ai.com/multi_context_convert/v1/model.tar.gz",
-        "convert-ubuntu": "http://models.poly-ai.com/ubuntu_convert/v1/model.tar.gz",
+        "convert": "https://github.com/PolyAI-LDN/polyai-models/releases/download/v1.0/model.tar.gz",
+        "convert-multi-context": "https://github.com/PolyAI-LDN/polyai-models/releases/download/v1.0/model_multicontext.tar.gz",
+        "convert-ubuntu": "https://github.com/PolyAI-LDN/polyai-models/releases/download/v1.0/model_ubuntu.tar.gz",
     }
 
     MODEL_SIGNATURES = [


### PR DESCRIPTION
It seems that the ConveRT models' URLs [have been recently changed](https://github.com/PolyAI-LDN/polyai-models/commit/ef5c0be03a361f093b2924bf62f35b100497c19d). This PR updates them to the new URLs.

As a side note, this is the root cause of the failure in automated tests in #234.

---
**TODOs:**
- [X] Update the URLs of all three ConveRT models.

---
**Backwards incompatible changes:** None.