### PR TITLE
Skip Ivis tests temporarily

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -37,8 +37,10 @@ transformers = [
     Tsne(2, n_iter=250),
     Tsne(3, n_iter=250),
     OpenTsne(2, n_iter=2),
-    Ivis(2, k=10, batch_size=10, epochs=10),
-    Ivis(3, k=10, batch_size=10, epochs=10),
+    # BUG: ivis tests fail due to tqdm bug in macOS
+    # SEE: https://github.com/tqdm/tqdm/issues/1037
+    # Ivis(2, k=10, batch_size=10, epochs=10),
+    # Ivis(3, k=10, batch_size=10, epochs=10),
     Normalizer(),
     Normalizer(feature=True),
 ]
@@ -62,7 +64,9 @@ def test_transformations_new_size(transformer, extra_size):
         Noise(0.1),
         Tsne(2, n_iter=250),
         OpenTsne(2, n_iter=1),
-        Ivis(2, k=10, batch_size=10, epochs=10),
+        # BUG: ivis tests fail due to tqdm bug in macOS
+        # SEE: https://github.com/tqdm/tqdm/issues/1037
+        # Ivis(2, k=10, batch_size=10, epochs=10),
         AddRandom(n=4),
         lambda d: d | (d["man"] - d["woman"]),
         Normalizer(),
@@ -83,7 +87,9 @@ def test_transformations_keep_props(transformer):
         AddRandom(n=4),
         Tsne(2, n_iter=250),
         OpenTsne(2, n_iter=2),
-        Ivis(2, k=10, batch_size=10, epochs=10),
+        # BUG: ivis tests fail due to tqdm bug in macOS
+        # SEE: https://github.com/tqdm/tqdm/issues/1037
+        # Ivis(2, k=10, batch_size=10, epochs=10),
         Normalizer(),
     ],
 )


### PR DESCRIPTION
This PR temporarily comments out the Ivis tests until the external problem, which is probably due to `tqdm`, is resolved.