### PR TITLE
#228 Assign should accept Values

### DIFF
--- a/tests/test_embeddingset.py
+++ b/tests/test_embeddingset.py
@@ -211,7 +211,7 @@ def test_add_property():
     assert all([e.prop_a == "prop-one" for e in emb_with_property])
 
 
-def test_assign():
+def test_assign_base():
     foo = Embedding("foo", [0.1, 0.3, 0.10])
     bar = Embedding("bar", [0.7, 0.2, 0.11])
     emb = EmbeddingSet(foo, bar)
@@ -220,3 +220,31 @@ def test_assign():
     )
     assert all([e.prop_a == "prop-one" for e in emb_with_property])
     assert all([e.prop_b == "prop-two" for e in emb_with_property])
+
+
+def test_assign_literal_values():
+    foo = Embedding("foo", [0.1, 0.3, 0.10])
+    bar = Embedding("bar", [0.7, 0.2, 0.11])
+    emb = EmbeddingSet(foo, bar)
+    emb_with_property = emb.assign(prop_a="prop-one", prop_b=1)
+    assert all([e.prop_a == "prop-one" for e in emb_with_property])
+    assert all([e.prop_b == 1 for e in emb_with_property])
+
+
+def test_assign_arrays():
+    foo = Embedding("foo", [0.1, 0.3, 0.10])
+    bar = Embedding("bar", [0.7, 0.2, 0.11])
+    emb = EmbeddingSet(foo, bar)
+    emb_with_property = emb.assign(prop_a=["a", "b"], prop_b=np.array([1, 2]))
+    assert emb_with_property["foo"].prop_a == "a"
+    assert emb_with_property["bar"].prop_a == "b"
+    assert emb_with_property["foo"].prop_b == 1
+    assert emb_with_property["bar"].prop_b == 2
+
+
+def test_assign_arrays_raise_error():
+    foo = Embedding("foo", [0.1, 0.3, 0.10])
+    bar = Embedding("bar", [0.7, 0.2, 0.11])
+    emb = EmbeddingSet(foo, bar)
+    with pytest.raises(ValueError):
+        emb_with_property = emb.assign(prop_a=["a", "b"], prop_b=np.array([1, 2, 3]))


### PR DESCRIPTION
This PR tries to adress https://github.com/RasaHQ/whatlies/issues/228. We now allow for this; 

```python
from whatlies.embeddingset import EmbeddingSet

foo = Embedding("foo", [0.1, 0.3, 0.10])
bar = Embedding("bar", [0.7, 0.2, 0.11])
emb = EmbeddingSet(foo, bar)
emb_with_property1 = emb.assign(dim0=lambda d: d.vector[0],
                                dim1=lambda d: d.vector[1],
                                dim2=lambda d: d.vector[2])

emb_with_property2 = emb.assign(group=["foo_grp", "bar_grp"])

emb_with_property3 = emb.assign(constant=1)
```

Note that we will throw an error if we were to do; 

```python
emb_with_property4 = emb.assign(group=["foo_grp", "bar_grp", "dimension_misalign"])
```