### PR TITLE
Scikit-Learn 0.24 Compatilibity

### DIFF
--- a/whatlies/language/_bpemblang.py
+++ b/whatlies/language/_bpemblang.py
@@ -56,6 +56,10 @@ class BytePairLanguage(SklearnTransformerMixin):
     def __init__(
         self, lang, vs=10000, dim=100, cache_dir=Path.home() / Path(".cache/bpemb")
     ):
+        self.lang = lang
+        self.vs = vs
+        self.dim = dim
+        self.cache_dir = cache_dir
         self.module = BPEmb(lang=lang, vs=vs, dim=dim, cache_dir=cache_dir)
 
     def __getitem__(self, item):

--- a/whatlies/language/_countvector_lang.py
+++ b/whatlies/language/_countvector_lang.py
@@ -67,6 +67,15 @@ class CountVectorLanguage(SklearnTransformerMixin):
         strip_accents: str = None,
         random_state: int = 42,
     ):
+        self.n_components = n_components
+        self.lowercase = lowercase
+        self.analyzer = analyzer
+        self.ngram_range = ngram_range
+        self.min_df = min_df
+        self.max_df = max_df
+        self.binary = binary
+        self.strip_accents = strip_accents
+        self.random_state = random_state
         self.svd = TruncatedSVD(n_components=n_components, random_state=random_state)
         self.cv = CountVectorizer(
             lowercase=lowercase,

--- a/whatlies/language/_gensim_lang.py
+++ b/whatlies/language/_gensim_lang.py
@@ -64,6 +64,7 @@ class GensimLanguage(SklearnTransformerMixin):
     """
 
     def __init__(self, keyedfile):
+        self.keyedfile = keyedfile
         self.kv = KeyedVectors.load(keyedfile)
 
     def __getitem__(self, query: Union[str, List[str]]):

--- a/whatlies/language/_hftransformers_lang.py
+++ b/whatlies/language/_hftransformers_lang.py
@@ -46,6 +46,8 @@ class HFTransformersLanguage(SklearnTransformerMixin):
     """
 
     def __init__(self, model_name_or_path: str, **kwargs: Any) -> None:
+        self.model_name_or_path = model_name_or_path
+        self.kwargs = kwargs
         self.model = trf.pipeline(
             task="feature-extraction", model=model_name_or_path, **kwargs
         )

--- a/whatlies/language/_sense2vec_lang.py
+++ b/whatlies/language/_sense2vec_lang.py
@@ -29,6 +29,7 @@ class Sense2VecLanguage:
     """
 
     def __init__(self, sense2vec_path):
+        self.sense2vec_path = sense2vec_path
         self.s2v = Sense2Vec().from_disk(sense2vec_path)
 
     def __getitem__(self, query):

--- a/whatlies/language/_tfhub_lang.py
+++ b/whatlies/language/_tfhub_lang.py
@@ -64,6 +64,8 @@ class TFHubLanguage(SklearnTransformerMixin):
         if signature:
             model = model.signatures[signature]
         self.signature = signature
+        self.url = url
+        self.tags = tags
         self.model = model
 
     def __getitem__(

--- a/whatlies/language/_tfidf_lang.py
+++ b/whatlies/language/_tfidf_lang.py
@@ -67,6 +67,15 @@ class TFIDFVectorLanguage(SklearnTransformerMixin):
         strip_accents: str = None,
         random_state: int = 42,
     ):
+        self.n_components = n_components
+        self.lowercase = lowercase
+        self.analyzer = analyzer
+        self.ngram_range = ngram_range
+        self.min_df = min_df
+        self.max_df = max_df
+        self.binary = binary
+        self.strip_accents = strip_accents
+        self.random_state = random_state
         self.svd = TruncatedSVD(n_components=n_components, random_state=random_state)
         self.cv = TfidfVectorizer(
             lowercase=lowercase,


### PR DESCRIPTION
I noticed a lot of warnings containing; 

```
/home/vincent/Development/whatlies/venv/lib/python3.8/site-packages/sklearn/base.py:209: 
FutureWarning: From version 0.24, get_params will raise an AttributeError if a parameter 
cannot be retrieved as an instance attribute. Previously it would return None.
```

So after a quick [investigation](https://stackoverflow.com/questions/63251437/futurewarning-get-params-from-scikit-learn) I found the fix for it. This also makes the library robust on the new sklearn version. 