### PR TITLE
add color ranked text in plot brush

### DIFF
--- a/whatlies/embeddingset.py
+++ b/whatlies/embeddingset.py
@@ -1318,7 +1318,10 @@ class EmbeddingSet:
         ranked_text = (
             alt.Chart(plot_df)
             .mark_text()
-            .encode(y=alt.Y("row_number:O", axis=None))
+            .encode(
+                y=alt.Y("row_number:O", axis=None),
+                color=alt.Color(":N", legend=None) if not color else alt.Color(color),
+            )
             .transform_window(row_number="row_number()")
             .transform_filter(brush)
             .transform_window(rank="rank(row_number)")


### PR DESCRIPTION
Small suggestion to improve the readability of the brush plot.
Now you can als see to which group the ranked text belongs.
This is particularly helpful when your embedding+dimension reduction method isn't able to separate the different groups.

Current situation:
![image](https://user-images.githubusercontent.com/9828683/112055784-93062080-8b57-11eb-99f9-44ea91816819.png)

Proposal:
![image](https://user-images.githubusercontent.com/9828683/112055796-97323e00-8b57-11eb-8dc8-9bd76ad13ee2.png)
